### PR TITLE
Add console

### DIFF
--- a/src/cbk_test.zig
+++ b/src/cbk_test.zig
@@ -33,7 +33,12 @@ pub fn generate() []gen.API {
 }
 
 // exec tests
-pub fn exec(isolate: v8.Isolate, globals: v8.ObjectTemplate) !eng.ExecRes {
+pub fn exec(
+    isolate: v8.Isolate,
+    globals: v8.ObjectTemplate,
+    tpls: []gen.ProtoTpl,
+    comptime apis: []gen.API,
+) !eng.ExecRes {
 
     // create v8 context
     var context = v8.Context.init(isolate, globals, null);

--- a/src/console.zig
+++ b/src/console.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+
+pub const Console = struct {
+    // TODO: configurable writer
+
+    pub fn log(_: Console, str: []const u8) void {
+        std.debug.print("== JS console: {s} ==\n", .{str});
+    }
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -41,8 +41,18 @@ fn benchWithoutIsolate(
 ) !bench.Result {
     var ba = bench.allocator(alloc);
     const s = struct {
-        fn do(isolate: v8.Isolate, globals: v8.ObjectTemplate) !eng.ExecRes {
-            const t = try bench.call(execFn, .{ isolate, globals }, iter, warmup);
+        fn do(
+            isolate: v8.Isolate,
+            globals: v8.ObjectTemplate,
+            tpls: []gen.ProtoTpl,
+            comptime apis_scoped: []gen.API,
+        ) !eng.ExecRes {
+            const t = try bench.call(
+                execFn,
+                .{ isolate, globals, tpls, apis_scoped },
+                iter,
+                warmup,
+            );
             return eng.ExecRes{ .Time = t };
         }
     };

--- a/src/proto_test.zig
+++ b/src/proto_test.zig
@@ -63,7 +63,12 @@ pub fn generate() []gen.API {
 }
 
 // exec tests
-pub fn exec(isolate: v8.Isolate, globals: v8.ObjectTemplate) !eng.ExecRes {
+pub fn exec(
+    isolate: v8.Isolate,
+    globals: v8.ObjectTemplate,
+    _: []gen.ProtoTpl,
+    comptime _: []gen.API,
+) !eng.ExecRes {
 
     // create v8 context
     var context = v8.Context.init(isolate, globals, null);

--- a/src/reflect.zig
+++ b/src/reflect.zig
@@ -241,6 +241,7 @@ pub const Func = struct {
 pub const Struct = struct {
     // struct info
     name: []const u8,
+    js_name: []const u8,
     T: type,
     mem_layout: std.builtin.Type.ContainerLayout,
 
@@ -411,6 +412,7 @@ pub const Struct = struct {
         var s = Struct{
             // struct info
             .name = struct_name,
+            .js_name = jsName(struct_name),
             .T = T,
             .mem_layout = obj.Struct.layout,
 

--- a/src/types_primitives.zig
+++ b/src/types_primitives.zig
@@ -98,7 +98,7 @@ pub fn jsToNative(alloc: std.mem.Allocator, comptime zig_T: refl.Type, js_val: v
     switch (zig_T.T) {
 
         // list of bytes (including strings)
-        []u8, ?[]u8 => {
+        []u8, ?[]u8, []const u8, ?[]const u8 => {
             const buf = try utils.valueToUtf8(alloc, js_val, isolate, ctx);
             if (Store.default != null) {
                 try Store.default.?.addString(buf);

--- a/src/types_primitives_test.zig
+++ b/src/types_primitives_test.zig
@@ -95,7 +95,12 @@ pub fn generate() []gen.API {
 }
 
 // exec tests
-pub fn exec(isolate: v8.Isolate, globals: v8.ObjectTemplate) !eng.ExecRes {
+pub fn exec(
+    isolate: v8.Isolate,
+    globals: v8.ObjectTemplate,
+    _: []gen.ProtoTpl,
+    comptime _: []gen.API,
+) !eng.ExecRes {
 
     // create v8 context
     var context = v8.Context.init(isolate, globals, null);


### PR DESCRIPTION
We are just overriding the v8 builtin console with a native API one. Maybe there is a better option, or a way to connect to v8 builtin console, but this solution is easier.

Signed-off-by: Francis Bouvier <francis.bouvier@gmail.com>