### PR TITLE
Add shell

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,98 +1,200 @@
 const std = @import("std");
 
+const pkgs = packages("");
+
 pub fn build(b: *std.build.Builder) !void {
     const target = b.standardTargetOptions(.{});
     const mode = b.standardReleaseOptions();
 
+    // TODO: install only bench or shell with zig build <cmd>
+
+    // bench
+    // -----
+
     // compile and install
-    const exe = b.addExecutable("jsengine", "src/main.zig");
-    exe.setTarget(target);
-    exe.setBuildMode(mode);
-    exe.single_threaded = true;
-    try linkV8(exe, mode);
-    addDeps(exe);
+    const bench = b.addExecutable("jsruntime-bench", "src/main_bench.zig");
+    try common(bench, mode, target);
+    bench.single_threaded = true;
     if (mode == .ReleaseSafe) {
         // remove debug info
         // TODO: check if mandatory in release-safe
-        exe.strip = true;
+        bench.strip = true;
     }
-    exe.install();
+    bench.install();
 
     // run
-    const run_cmd = exe.run();
-    run_cmd.step.dependOn(b.getInstallStep());
+    const bench_cmd = bench.run();
+    bench_cmd.step.dependOn(b.getInstallStep());
     if (b.args) |args| {
-        run_cmd.addArgs(args);
+        bench_cmd.addArgs(args);
     }
 
-    const run_step = b.step("run", "Run the app");
-    run_step.dependOn(&run_cmd.step);
+    // step
+    const bench_step = b.step("bench", "Run basic benchmark");
+    bench_step.dependOn(&bench_cmd.step);
+
+    // shell
+    // -----
+
+    // compile and install
+    const shell = b.addExecutable("jsruntime-shell", "src/main_shell.zig");
+    try common(shell, mode, target);
+    try pkgs.add_shell(shell, mode);
+    if (mode == .ReleaseSafe) {
+        // remove debug info
+        // TODO: check if mandatory in release-safe
+        shell.strip = true;
+    }
+    // do not install shell binary
+    // shell.install();
+
+    // run
+    const shell_cmd = shell.run();
+    shell_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        shell_cmd.addArgs(args);
+    }
+
+    // step
+    const shell_step = b.step("shell", "Run JS shell");
+    shell_step.dependOn(&shell_cmd.step);
 
     // test
-    const test_exe = b.addTest("src/main.zig");
-    test_exe.setTarget(target);
-    test_exe.setBuildMode(mode);
-    test_exe.single_threaded = true;
-    try linkV8(test_exe, mode);
-    addDeps(test_exe);
+    // ----
 
+    // compile
+    const test_exe = b.addTest("src/tests.zig");
+    try common(test_exe, mode, target);
+    test_exe.single_threaded = true;
+
+    // step
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&test_exe.step);
 }
 
-fn addDeps(step: *std.build.LibExeObjStep) void {
-    // tigerbeetle IO loop
-    // incompatible stage1 and stage2 versions
-    if (step.builder.use_stage1 != null and step.builder.use_stage1.?) {
-        step.addPackagePath("tigerbeetle-io", "deps/tigerbeetle-io/io_stage1.zig");
-    } else {
-        step.addPackagePath("tigerbeetle-io", "deps/tigerbeetle-io/io.zig");
-    }
+fn common(
+    step: *std.build.LibExeObjStep,
+    mode: std.builtin.Mode,
+    target: std.zig.CrossTarget,
+) !void {
+    step.setTarget(target);
+    step.setBuildMode(mode);
+    step.addPackage(try pkgs.tigerbeetle_io(step));
+    step.addPackage(try pkgs.zig_v8(step));
+    try pkgs.v8(step, mode);
 }
 
-fn linkV8(step: *std.build.LibExeObjStep, mode: std.builtin.Mode) !void {
-    const mode_str: []const u8 = if (mode == .Debug) "debug" else "release";
-    // step.linkLibC(); // TODO: do we need to link libc?
+pub fn packages(comptime vendor_path: []const u8) type {
+    return struct {
+        const Self = @This();
 
-    // v8 library
-    // FIXME: we are tied to native v8 builds, currently:
-    // - aarch64-macos
-    // - x86_64-linux
-    const os = step.target.getOsTag();
-    const arch = step.target.getCpuArch();
-    switch (os) {
-        .linux => blk: {
-            if (arch != .x86_64) {
-                std.debug.print("only x86_64 are supported on linux builds\n", .{});
-                return error.ArchNotSupported;
-            }
-            // TODO: why do we need it? It should be linked already when we built v8
-            step.linkLibCpp();
-            break :blk;
-        },
-        .macos => blk: {
-            if (arch != .aarch64) {
-                std.debug.print("only aarch64 are supported on macos builds\n", .{});
-                return error.ArchNotSupported;
-            }
-            break :blk;
-        },
-        else => return error.OsNotSupported,
-    }
-    const lib_path = try std.fmt.allocPrint(
-        step.builder.allocator,
-        "../zig-v8/v8-build/{s}-{s}/{s}/ninja/obj/zig/libc_v8.a",
-        .{ @tagName(arch), @tagName(os), mode_str },
-    );
-    step.addObjectFile(lib_path);
+        fn tigerbeetle_io(step: *std.build.LibExeObjStep) !std.build.Pkg {
+            const lib_path = try std.fmt.allocPrint(
+                step.builder.allocator,
+                "{s}deps/tigerbeetle-io/io.zig",
+                .{vendor_path},
+            );
+            return .{
+                .name = "tigerbeetle-io",
+                .source = .{ .path = lib_path },
+            };
+        }
 
-    // v8 bindings
-    // stage2 is using int (0/1) from C bool
-    // while stage1 uses bool
-    if (step.builder.use_stage1 != null and step.builder.use_stage1.?) {
-        step.addPackagePath("v8", "deps/zig-v8/v8_stage1.zig");
-    } else {
-        step.addPackagePath("v8", "deps/zig-v8/v8.zig");
-    }
-    step.addIncludePath("deps/zig-v8");
+        fn zig_v8(step: *std.build.LibExeObjStep) !std.build.Pkg {
+            const include_path = try std.fmt.allocPrint(
+                step.builder.allocator,
+                "{s}deps/zig-v8",
+                .{vendor_path},
+            );
+            step.addIncludePath(include_path);
+
+            const lib_path = try std.fmt.allocPrint(
+                step.builder.allocator,
+                "{s}deps/zig-v8/v8.zig",
+                .{vendor_path},
+            );
+            return .{
+                .name = "v8",
+                .source = .{ .path = lib_path },
+            };
+        }
+
+        fn v8(step: *std.build.LibExeObjStep, mode: std.builtin.Mode) !void {
+            const mode_str: []const u8 = if (mode == .Debug) "debug" else "release";
+            // step.linkLibC(); // TODO: do we need to link libc?
+
+            // FIXME: we are tied to native v8 builds, currently:
+            // - aarch64-macos
+            // - x86_64-linux
+            const os = step.target.getOsTag();
+            const arch = step.target.getCpuArch();
+            switch (os) {
+                .linux => blk: {
+                    if (arch != .x86_64) {
+                        std.debug.print("only x86_64 are supported on linux builds\n", .{});
+                        return error.ArchNotSupported;
+                    }
+                    // TODO: why do we need it? It should be linked already when we built v8
+                    step.linkLibCpp();
+                    break :blk;
+                },
+                .macos => blk: {
+                    if (arch != .aarch64) {
+                        std.debug.print("only aarch64 are supported on macos builds\n", .{});
+                        return error.ArchNotSupported;
+                    }
+                    break :blk;
+                },
+                else => return error.OsNotSupported,
+            }
+
+            const lib_path = try std.fmt.allocPrint(
+                step.builder.allocator,
+                "{s}../zig-v8/v8-build/{s}-{s}/{s}/ninja/obj/zig/libc_v8.a",
+                .{ vendor_path, @tagName(arch), @tagName(os), mode_str },
+            );
+            step.addObjectFile(lib_path);
+        }
+
+        pub fn add_shell(step: *std.build.LibExeObjStep, _: std.builtin.Mode) !void {
+            const include_path = try std.fmt.allocPrint(
+                step.builder.allocator,
+                "{s}deps/linenoise",
+                .{vendor_path},
+            );
+            step.addIncludePath(include_path);
+
+            const lib_path = try std.fmt.allocPrint(
+                step.builder.allocator,
+                "{s}deps/linenoise/linenoise.c",
+                .{vendor_path},
+            );
+            const lib = step.builder.addStaticLibrary("linenoise", null);
+            // TODO: use mode to add debug/release flags
+            const cflags = [_][]const u8{};
+            lib.addCSourceFile(lib_path, &cflags);
+            step.linkLibrary(lib);
+        }
+
+        pub fn add(step: *std.build.LibExeObjStep, mode: std.builtin.Mode) !void {
+            const tigerbeetle_io_pkg = try Self.tigerbeetle_io(step);
+            const zig_v8_pkg = try Self.zig_v8(step);
+            try Self.v8(step, mode);
+
+            const lib_path = try std.fmt.allocPrint(
+                step.builder.allocator,
+                "{s}src/engine.zig",
+                .{vendor_path},
+            );
+            const lib = std.build.Pkg{
+                .name = "jsruntime",
+                .source = .{ .path = lib_path },
+                .dependencies = &[_]std.build.Pkg{
+                    tigerbeetle_io_pkg,
+                    zig_v8_pkg,
+                },
+            };
+            step.addPackage(lib);
+        }
+    };
 }

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -11,6 +11,7 @@ const gen = @import("generate.zig");
 const refl = @import("reflect.zig");
 
 pub const compile = gen.compile;
+pub const shell = @import("shell.zig").shell;
 
 pub const ExecRes = union(enum) {
     OK: void,

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 const v8 = @import("v8");
-const IO = @import("tigerbeetle-io").IO;
+pub const IO = @import("tigerbeetle-io").IO;
 
 const JSCallback = @import("callback.zig").Func;
 

--- a/src/main_bench.zig
+++ b/src/main_bench.zig
@@ -10,8 +10,6 @@ const bench = @import("bench.zig");
 const pretty = @import("pretty.zig");
 
 const proto = @import("proto_test.zig");
-const primitive_types = @import("types_primitives_test.zig");
-const callback = @import("cbk_test.zig");
 
 const kb = 1024;
 const us = std.time.ns_per_us;
@@ -74,11 +72,6 @@ fn benchWithoutIsolate(
     };
 }
 
-fn setTitle(comptime title: []const u8, comptime iter: comptime_int) ![]u8 {
-    var buf: [100]u8 = undefined;
-    return try std.fmt.bufPrint(buf[0..], title, .{iter});
-}
-
 pub fn main() !void {
 
     // benchmark conf
@@ -133,63 +126,5 @@ pub fn main() !void {
     try t.addRow(.{ "With Isolate", dur1, res1.alloc_nb, size1 });
     try t.addRow(.{ "Without Isolate", dur2, res2.alloc_nb, size2 });
     const out = std.io.getStdOut().writer();
-    try t.render(out);
-}
-
-test {
-
-    // create v8 vm
-    const vm = eng.VM.init();
-    defer vm.deinit();
-
-    // base and prototype tests
-    const proto_apis = comptime proto.generate(); // stage1: we need comptime
-    var proto_alloc = bench.allocator(std.testing.allocator);
-    _ = try eng.Load(proto_alloc.allocator(), false, proto.exec, proto_apis);
-    const proto_alloc_stats = proto_alloc.stats();
-    const proto_alloc_size = pretty.Measure{
-        .unit = "b",
-        .value = proto_alloc_stats.alloc_size,
-    };
-
-    // primitive types tests
-    const prim_apis = comptime primitive_types.generate(); // stage1: we need to comptime
-    var prim_alloc = bench.allocator(std.testing.allocator);
-    _ = try eng.Load(prim_alloc.allocator(), false, primitive_types.exec, prim_apis);
-    const prim_alloc_stats = prim_alloc.stats();
-    const prim_alloc_size = pretty.Measure{
-        .unit = "b",
-        .value = prim_alloc_stats.alloc_size,
-    };
-
-    // callback tests
-    const cbk_apis = comptime callback.generate(); // stage1: we need comptime
-    var cbk_alloc = bench.allocator(std.testing.allocator);
-    _ = try eng.Load(cbk_alloc.allocator(), false, callback.exec, cbk_apis);
-    const cbk_alloc_stats = cbk_alloc.stats();
-    const cbk_alloc_size = pretty.Measure{
-        .unit = "b",
-        .value = cbk_alloc_stats.alloc_size,
-    };
-
-    // benchmark table
-    const row_shape = .{
-        []const u8,
-        u64,
-        pretty.Measure,
-    };
-    const header = .{
-        "FUNCTION",
-        "ALLOCATIONS",
-        "HEAP SIZE",
-    };
-    const table = try pretty.GenerateTable(3, row_shape, pretty.TableConf{ .margin_left = "  " });
-    const title = "Test jsengine ✅";
-    var t = table.init(title, header);
-    try t.addRow(.{ "Prototype", proto_alloc.alloc_nb, proto_alloc_size });
-    try t.addRow(.{ "Primitives", prim_alloc.alloc_nb, prim_alloc_size });
-    try t.addRow(.{ "Callbacks", cbk_alloc.alloc_nb, cbk_alloc_size });
-
-    const out = std.io.getStdErr().writer();
     try t.render(out);
 }

--- a/src/main_shell.zig
+++ b/src/main_shell.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+
+const eng = @import("engine.zig");
+
+const shell = @import("shell.zig").shell;
+
+const callback = @import("cbk_test.zig");
+
+pub fn main() !void {
+
+    // generate APIs
+    const apis = comptime callback.generate();
+
+    // create v8 vm
+    const vm = eng.VM.init();
+    defer vm.deinit();
+
+    // alloc
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    // launch shell
+    try shell(alloc, apis, "/tmp/jsruntime-shell.sock");
+}

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -1,0 +1,279 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const v8 = @import("v8");
+const c = @cImport({
+    @cInclude("linenoise.h");
+});
+
+const utils = @import("utils.zig");
+const eng = @import("engine.zig");
+const gen = @import("generate.zig");
+
+const Loop = @import("loop.zig").SingleThreaded;
+const IO = @import("loop.zig").IO;
+
+var socket_p: []const u8 = undefined;
+
+// I/O connection context
+const ConnContext = struct {
+    socket: std.os.socket_t,
+
+    cmdContext: *CmdContext,
+};
+
+// I/O connection callback
+fn connCallback(
+    ctx: *ConnContext,
+    completion: *IO.Completion,
+    result: IO.AcceptError!std.os.socket_t,
+) void {
+    ctx.cmdContext.socket = result catch |err| @panic(@errorName(err));
+
+    // launch receving messages asynchronously
+    ctx.cmdContext.loop.io.recv(
+        *CmdContext,
+        ctx.cmdContext,
+        cmdCallback,
+        completion,
+        ctx.cmdContext.socket,
+        ctx.cmdContext.buf,
+    );
+}
+
+// I/O input command context
+const CmdContext = struct {
+    loop: *Loop,
+    socket: std.os.socket_t,
+    buf: []u8,
+    close: bool = false,
+
+    isolate: v8.Isolate,
+    js_ctx: v8.Context,
+    try_catch: *v8.TryCatch,
+};
+
+// I/O input command callback
+fn cmdCallback(
+    ctx: *CmdContext,
+    completion: *IO.Completion,
+    result: IO.RecvError!usize,
+) void {
+    const size = result catch |err| {
+        ctx.close = true;
+        std.debug.print("recv error: {s}\n", .{@errorName(err)});
+        return;
+    };
+
+    const input = ctx.buf[0..size];
+
+    // close on exit command
+    if (std.mem.eql(u8, input, "exit")) {
+        ctx.close = true;
+        return;
+    }
+
+    // JS execute
+    const res = eng.jsExecScript(
+        utils.allocator,
+        ctx.isolate,
+        ctx.js_ctx,
+        input,
+        "shell.js",
+        ctx.try_catch.*,
+    );
+    defer res.deinit();
+
+    // JS print result
+    var success = if (res.success) "<- " else "";
+    printStdout("{s}{s}\n", .{ success, res.result });
+
+    // acknowledge to repl result has been printed
+    _ = std.os.write(ctx.socket, "ok") catch unreachable;
+
+    // continue receving messages asynchronously
+    ctx.loop.io.recv(
+        *CmdContext,
+        ctx,
+        cmdCallback,
+        completion,
+        ctx.socket,
+        ctx.buf,
+    );
+}
+
+fn shellExec(
+    loop: *Loop,
+    isolate: v8.Isolate,
+    globals: v8.ObjectTemplate,
+    tpls: []gen.ProtoTpl,
+    comptime apis: []gen.API,
+) !eng.ExecRes {
+
+    // create internal server listening on a unix socket
+    var addr = try std.net.Address.initUnix(socket_p);
+    var server = std.net.StreamServer.init(.{ .reuse_address = true });
+    defer server.deinit();
+    try server.listen(addr);
+
+    // launch repl in a separate detached thread
+    var repl_thread = try std.Thread.spawn(.{}, repl, .{});
+    repl_thread.detach();
+
+    // create JS context
+    var js_ctx = v8.Context.init(isolate, globals, null);
+    js_ctx.enter();
+    defer js_ctx.exit();
+
+    // add console
+    _ = try eng.createV8Object(
+        utils.allocator,
+        isolate,
+        js_ctx,
+        js_ctx.getGlobal(),
+        tpls[0].tpl,
+        apis[0].T_refl,
+    );
+
+    // JS try cache
+    var try_catch: v8.TryCatch = undefined;
+    try_catch.init(isolate);
+    defer try_catch.deinit();
+
+    // create I/O contexts and callbacks
+    // for accepting connections and receving messages
+    var input: [1024]u8 = undefined;
+    var cmd_ctx = CmdContext{
+        .loop = loop,
+        .socket = undefined,
+        .buf = &input,
+        .isolate = isolate,
+        .js_ctx = js_ctx,
+        .try_catch = &try_catch,
+    };
+    var conn_ctx = ConnContext{
+        .socket = server.sockfd.?,
+        .cmdContext = &cmd_ctx,
+    };
+    var completion: IO.Completion = undefined;
+
+    // launch accepting connection asynchronously on internal server
+    loop.io.accept(
+        *ConnContext,
+        &conn_ctx,
+        connCallback,
+        &completion,
+        server.sockfd.?,
+    );
+
+    // infinite loop on I/O events, either:
+    // - user input command from repl
+    // - JS callbacks events from scripts
+    while (true) {
+        try loop.io.tick();
+        if (loop.cbk_error) {
+            if (try_catch.getException()) |msg| {
+                const except = try utils.valueToUtf8(
+                    utils.allocator,
+                    msg,
+                    isolate,
+                    js_ctx,
+                );
+                printStdout("\n\rUncaught {s}\n\r", .{except});
+                utils.allocator.free(except);
+            }
+            loop.cbk_error = false;
+        }
+        if (cmd_ctx.close) {
+            break;
+        }
+    }
+
+    return eng.ExecOK;
+}
+
+fn repl() !void {
+
+    // greetings
+    printStdout(
+        \\JS Repl
+        \\exit with Ctrl+D or "exit"
+        \\
+    , .{});
+
+    // create a socket client connected to the internal server
+    const socket = try std.net.connectUnixSocket(socket_p);
+
+    var ack: [2]u8 = undefined;
+
+    // infinite loop
+    while (true) {
+
+        // linenoise lib
+        const line = c.linenoise("> ");
+
+        if (line != null) {
+            const input = std.mem.sliceTo(line.?, 0);
+
+            // continue if input empty
+            if (input.len == 0) {
+                // free the line
+                c.linenoiseFree(line);
+                continue;
+            }
+
+            // stop loop on exit input
+            if (std.mem.eql(u8, input, "exit") or
+                std.mem.eql(u8, input, "exit;"))
+            {
+                // free the line
+                c.linenoiseFree(line);
+                break;
+            }
+
+            // send the input command to the internal server
+            _ = try socket.write(input);
+
+            // free the line
+            c.linenoiseFree(line);
+
+            // aknowledge response from the internal server
+            // before giving back the input to the user
+            _ = socket.read(&ack) catch |err| {
+                std.debug.print("ack error: {s}\n", .{@errorName(err)});
+                // stop loop on ack read error
+                break;
+            };
+        } else {
+
+            // stop loop on Ctrl+D
+            break;
+        }
+    }
+
+    // send the exit command to the internal server
+    _ = try socket.write("exit");
+    printStdout("Goodbye...\n", .{});
+}
+
+pub fn shell(alloc: std.mem.Allocator, comptime apis: []gen.API, socket_path: []const u8) !void {
+    socket_p = socket_path;
+
+    // remove socket file of internal server
+    // reuse_address (SO_REUSEADDR flag) does not seems to work on unix socket
+    // see: https://gavv.net/articles/unix-socket-reuse/
+    // TODO: use a lock file instead
+    std.os.unlink(socket_p) catch |err| {
+        if (err != error.FileNotFound) {
+            return err;
+        }
+    };
+
+    // load v8
+    _ = try eng.Load(alloc, false, shellExec, apis);
+}
+
+fn printStdout(comptime format: []const u8, args: anytype) void {
+    const stdout = std.io.getStdOut().writer();
+    stdout.print(format, args) catch unreachable;
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+
+const eng = @import("engine.zig");
+
+const bench = @import("bench.zig");
+const pretty = @import("pretty.zig");
+
+const proto = @import("proto_test.zig");
+const primitive_types = @import("types_primitives_test.zig");
+const callback = @import("cbk_test.zig");
+
+test {
+
+    // create v8 vm
+    const vm = eng.VM.init();
+    defer vm.deinit();
+
+    // base and prototype tests
+    const proto_apis = comptime proto.generate(); // stage1: we need comptime
+    var proto_alloc = bench.allocator(std.testing.allocator);
+    _ = try eng.Load(proto_alloc.allocator(), false, proto.exec, proto_apis);
+    const proto_alloc_stats = proto_alloc.stats();
+    const proto_alloc_size = pretty.Measure{
+        .unit = "b",
+        .value = proto_alloc_stats.alloc_size,
+    };
+
+    // primitive types tests
+    const prim_apis = comptime primitive_types.generate(); // stage1: we need to comptime
+    var prim_alloc = bench.allocator(std.testing.allocator);
+    _ = try eng.Load(prim_alloc.allocator(), false, primitive_types.exec, prim_apis);
+    const prim_alloc_stats = prim_alloc.stats();
+    const prim_alloc_size = pretty.Measure{
+        .unit = "b",
+        .value = prim_alloc_stats.alloc_size,
+    };
+
+    // callback tests
+    const cbk_apis = comptime callback.generate(); // stage1: we need comptime
+    var cbk_alloc = bench.allocator(std.testing.allocator);
+    _ = try eng.Load(cbk_alloc.allocator(), false, callback.exec, cbk_apis);
+    const cbk_alloc_stats = cbk_alloc.stats();
+    const cbk_alloc_size = pretty.Measure{
+        .unit = "b",
+        .value = cbk_alloc_stats.alloc_size,
+    };
+
+    // benchmark table
+    const row_shape = .{
+        []const u8,
+        u64,
+        pretty.Measure,
+    };
+    const header = .{
+        "FUNCTION",
+        "ALLOCATIONS",
+        "HEAP SIZE",
+    };
+    const table = try pretty.GenerateTable(3, row_shape, pretty.TableConf{ .margin_left = "  " });
+    const title = "Test jsengine ✅";
+    var t = table.init(title, header);
+    try t.addRow(.{ "Prototype", proto_alloc.alloc_nb, proto_alloc_size });
+    try t.addRow(.{ "Primitives", prim_alloc.alloc_nb, prim_alloc_size });
+    try t.addRow(.{ "Callbacks", cbk_alloc.alloc_nb, cbk_alloc_size });
+
+    const out = std.io.getStdErr().writer();
+    try t.render(out);
+}


### PR DESCRIPTION
We use [linenoise](https://github.com/antirez/linenoise/) lib for line
editing support (without history or completions for now).

As _linenoise_ is blocking and we need non-blocking output for JS
callbacks we use a design based on 2 threads:

- the main thread handle the classic JS runtime work and listen user
commands comming from _linenoise_ on unix socket, using the same I/O
event loop as JS (so events can either be a JS callback or a user command)
- linenoise is launched in a dedicated thread and sends user input
commands to the main thread by writing on the unix socket

The build system has been changed to split main between the 2
executables (bench and shell) and the tests.

It was also refactor to allow better integration as a lib.

- Closes https://github.com/Browsercore/jsruntime-lib/issues/106