### PR TITLE
Refacto

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -183,7 +183,7 @@ pub fn packages(comptime vendor_path: []const u8) type {
 
             const lib_path = try std.fmt.allocPrint(
                 step.builder.allocator,
-                "{s}src/engine.zig",
+                "{s}src/jsruntime.zig",
                 .{vendor_path},
             );
             const lib = std.build.Pkg{

--- a/src/console.zig
+++ b/src/console.zig
@@ -12,36 +12,3 @@ pub const Console = struct {
         std.debug.print("== JS console: {s} ==\n", .{str});
     }
 };
-
-pub fn addAPI(comptime apis: []gen.API) []gen.API {
-    comptime var apis_with_console: [apis.len + 1]gen.API = undefined;
-    comptime {
-        var console_api = gen.compile(.{Console})[0];
-        console_api.T_refl.index = apis.len;
-        inline for (apis) |api, i| {
-            apis_with_console[i] = api;
-        }
-        apis_with_console[apis.len] = console_api;
-    }
-    return &apis_with_console;
-}
-
-pub fn load(
-    comptime apis: []gen.API,
-    tpls: []gen.ProtoTpl,
-    isolate: v8.Isolate,
-    context: v8.Context,
-) !void {
-
-    // create JS object
-    const console = Console{};
-    // TODO: use pointer (and allocator) here
-    try eng.createJSObject(
-        apis,
-        console,
-        tpls,
-        context.getGlobal(),
-        context,
-        isolate,
-    );
-}

--- a/src/generate.zig
+++ b/src/generate.zig
@@ -97,7 +97,7 @@ fn setReturnType(
     if (ret.T_refl_index) |index| {
 
         // return is a user defined type
-        const js_obj = TPLs[index].tpl.getInstanceTemplate().initInstance(ctx);
+        const js_obj = getTpl(index).tpl.getInstanceTemplate().initInstance(ctx);
         _ = setNativeObject(
             alloc,
             all_T[index],
@@ -528,6 +528,10 @@ pub fn compile(comptime types: anytype) []API {
 // Therefore the content of thoses lists (and their order) should not be altered
 // afterwards.
 var TPLs: []ProtoTpl = undefined;
+
+pub fn getTpl(index: usize) ProtoTpl {
+    return TPLs[index];
+}
 
 // Load native APIs into a JS isolate
 // This function is called at runtime.

--- a/src/jsruntime.zig
+++ b/src/jsruntime.zig
@@ -1,0 +1,18 @@
+// Public API
+// only imports, no implementation code
+
+pub const Loop = @import("loop.zig").SingleThreaded;
+pub const shell = @import("shell.zig").shell;
+pub const shellExec = @import("shell.zig").shellExec;
+pub const Console = @import("console.zig").Console;
+
+const gen = @import("generate.zig");
+pub const compile = gen.compile;
+pub const TPL = gen.ProtoTpl;
+pub const API = gen.API;
+
+const eng = @import("engine.zig");
+pub const VM = eng.VM;
+pub const loadEnv = eng.loadEnv;
+pub const Env = eng.Env;
+pub const ContextExecFn = eng.ContextExecFn;

--- a/src/main_shell.zig
+++ b/src/main_shell.zig
@@ -1,18 +1,16 @@
 const std = @import("std");
 
-const eng = @import("engine.zig");
+const jsruntime = @import("jsruntime.zig");
 
-const shell = @import("shell.zig").shell;
-
-const callback = @import("tests/cbk_test.zig");
+const Window = @import("tests/cbk_test.zig").Window;
 
 pub fn main() !void {
 
     // generate APIs
-    const apis = comptime callback.generate();
+    const apis = jsruntime.compile(.{ jsruntime.Console, Window });
 
-    // create v8 vm
-    const vm = eng.VM.init();
+    // create JS vm
+    const vm = jsruntime.VM.init();
     defer vm.deinit();
 
     // alloc
@@ -21,5 +19,5 @@ pub fn main() !void {
     const alloc = gpa.allocator();
 
     // launch shell
-    try shell(alloc, apis, "/tmp/jsruntime-shell.sock");
+    try jsruntime.shell(alloc, false, apis, null, "/tmp/jsruntime-shell.sock");
 }

--- a/src/run_tests.zig
+++ b/src/run_tests.zig
@@ -12,14 +12,14 @@ const callback = @import("tests/cbk_test.zig");
 
 test {
 
-    // create v8 vm
+    // create JS vm
     const vm = eng.VM.init();
     defer vm.deinit();
 
     // base and prototype tests
     const proto_apis = comptime proto.generate(); // stage1: we need comptime
     var proto_alloc = bench.allocator(std.testing.allocator);
-    _ = try eng.Load(proto_alloc.allocator(), false, proto.exec, proto_apis);
+    _ = try eng.loadEnv(proto_alloc.allocator(), false, proto.exec, proto_apis);
     const proto_alloc_stats = proto_alloc.stats();
     const proto_alloc_size = pretty.Measure{
         .unit = "b",
@@ -29,7 +29,7 @@ test {
     // primitive types tests
     const prim_apis = comptime primitive_types.generate(); // stage1: we need to comptime
     var prim_alloc = bench.allocator(std.testing.allocator);
-    _ = try eng.Load(prim_alloc.allocator(), false, primitive_types.exec, prim_apis);
+    _ = try eng.loadEnv(prim_alloc.allocator(), false, primitive_types.exec, prim_apis);
     const prim_alloc_stats = prim_alloc.stats();
     const prim_alloc_size = pretty.Measure{
         .unit = "b",
@@ -39,7 +39,7 @@ test {
     // native types tests
     const nat_apis = comptime native_types.generate(); // stage1: we need to comptime
     var nat_alloc = bench.allocator(std.testing.allocator);
-    _ = try eng.Load(nat_alloc.allocator(), false, native_types.exec, nat_apis);
+    _ = try eng.loadEnv(nat_alloc.allocator(), false, native_types.exec, nat_apis);
     const nat_alloc_stats = nat_alloc.stats();
     const nat_alloc_size = pretty.Measure{
         .unit = "b",
@@ -49,7 +49,7 @@ test {
     // callback tests
     const cbk_apis = comptime callback.generate(); // stage1: we need comptime
     var cbk_alloc = bench.allocator(std.testing.allocator);
-    _ = try eng.Load(cbk_alloc.allocator(), false, callback.exec, cbk_apis);
+    _ = try eng.loadEnv(cbk_alloc.allocator(), false, callback.exec, cbk_apis);
     const cbk_alloc_stats = cbk_alloc.stats();
     const cbk_alloc_size = pretty.Measure{
         .unit = "b",

--- a/src/tests/types_native_test.zig
+++ b/src/tests/types_native_test.zig
@@ -3,9 +3,7 @@ const std = @import("std");
 const v8 = @import("v8");
 
 const utils = @import("../utils.zig");
-const gen = @import("../generate.zig");
-const eng = @import("../engine.zig");
-const Loop = @import("../loop.zig").SingleThreaded;
+const jsruntime = @import("../jsruntime.zig");
 
 const tests = @import("test_utils.zig");
 
@@ -57,25 +55,22 @@ const Car = struct {
 };
 
 // generate API, comptime
-pub fn generate() []gen.API {
-    return gen.compile(.{ Brand, Car });
+pub fn generate() []jsruntime.API {
+    return jsruntime.compile(.{ Brand, Car });
 }
 
 // exec tests
 pub fn exec(
-    loop: *Loop,
-    isolate: v8.Isolate,
-    globals: v8.ObjectTemplate,
-    _: []gen.ProtoTpl,
-    comptime _: []gen.API,
-) !eng.ExecRes {
+    alloc: std.mem.Allocator,
+    js_env: *jsruntime.Env,
+    comptime _: []jsruntime.API,
+) !void {
 
-    // create v8 context
-    var context = v8.Context.init(isolate, globals, null);
-    context.enter();
-    defer context.exit();
+    // start JS env
+    js_env.start();
+    defer js_env.stop();
 
-    const cases = [_]tests.Case{
+    var cases = [_]tests.Case{
         .{ .src = "let car = new Car();", .ex = "undefined" },
 
         // basic tests for getter
@@ -104,7 +99,5 @@ pub fn exec(
         .{ .src = "brand1Ptr_again.name = 'Citroën'", .ex = "Citroën" },
         .{ .src = "brand1Ptr.name", .ex = "Citroën" },
     };
-    try tests.checkCases(loop, utils.allocator, isolate, context, cases.len, cases);
-
-    return eng.ExecOK;
+    try tests.checkCases(alloc, js_env, &cases);
 }


### PR DESCRIPTION
- Move engine public functions to methods of a new struct Env
- Simplify exec function provided to the engine load
- Create a header-like jsruntime file with all public APIs

Signed-off-by: Francis Bouvier <francis.bouvier@gmail.com>