### PR TITLE
v8: force JSResult.success=false on JSResult.setError()

### DIFF
--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -416,6 +416,7 @@ pub const JSResult = struct {
 
         // exception
         const except = try_catch.getException().?;
+        self.success = false;
         self.result = try valueToUtf8(alloc, except, isolate, context);
 
         // stack


### PR DESCRIPTION
When `res` is reused, it keeps the previous `success` value on `setError`. 