### PR TITLE
Return error in compile function

### DIFF
--- a/src/generate.zig
+++ b/src/generate.zig
@@ -28,13 +28,11 @@ const loadFn = private.loadFn;
 // Compile native types to native APIs
 // which can be later loaded in JS.
 // This function is called at comptime.
-pub fn compile(comptime types: anytype) []API {
+pub fn compile(comptime types: anytype) ![]API {
     comptime {
 
         // call types reflection
-        const all_T = refl.do(types) catch |err| {
-            @compileError(@errorName(err));
-        };
+        const all_T = try refl.do(types);
 
         // generate APIs
         var apis: [all_T.len]API = undefined;

--- a/src/main_bench.zig
+++ b/src/main_bench.zig
@@ -71,7 +71,7 @@ fn benchWithoutIsolate(
 pub fn main() !void {
 
     // generate APIs
-    const apis = comptime proto.generate(); // stage1: we need comptime
+    const apis = comptime try proto.generate(); // stage1: we need comptime
 
     // create JS vm
     const vm = public.VM.init();

--- a/src/main_shell.zig
+++ b/src/main_shell.zig
@@ -7,7 +7,7 @@ const Window = @import("tests/cbk_test.zig").Window;
 pub fn main() !void {
 
     // generate APIs
-    const apis = public.compile(.{ public.Console, Window });
+    const apis = comptime try public.compile(.{ public.Console, Window });
 
     // create JS vm
     const vm = public.VM.init();

--- a/src/run_tests.zig
+++ b/src/run_tests.zig
@@ -45,7 +45,7 @@ test {
     var proto_alloc: bench.Allocator = undefined;
     if (do_proto) {
         tests_nb += 1;
-        const proto_apis = comptime proto.generate(); // stage1: we need comptime
+        const proto_apis = comptime try proto.generate(); // stage1: we need comptime
         proto_alloc = bench.allocator(std.testing.allocator);
         var proto_arena = std.heap.ArenaAllocator.init(proto_alloc.allocator());
         defer proto_arena.deinit();
@@ -56,7 +56,7 @@ test {
     var prim_alloc: bench.Allocator = undefined;
     if (do_prim) {
         tests_nb += 1;
-        const prim_apis = comptime primitive_types.generate(); // stage1: we need to comptime
+        const prim_apis = comptime try primitive_types.generate(); // stage1: we need to comptime
         prim_alloc = bench.allocator(std.testing.allocator);
         var prim_arena = std.heap.ArenaAllocator.init(prim_alloc.allocator());
         defer prim_arena.deinit();
@@ -67,7 +67,7 @@ test {
     var nat_alloc: bench.Allocator = undefined;
     if (do_nat) {
         tests_nb += 1;
-        const nat_apis = comptime native_types.generate(); // stage1: we need to comptime
+        const nat_apis = comptime try native_types.generate(); // stage1: we need to comptime
         nat_alloc = bench.allocator(std.testing.allocator);
         var nat_arena = std.heap.ArenaAllocator.init(nat_alloc.allocator());
         defer nat_arena.deinit();
@@ -78,7 +78,7 @@ test {
     var complex_alloc: bench.Allocator = undefined;
     if (do_complex) {
         tests_nb += 1;
-        const complex_apis = comptime complex_types.generate(); // stage1: we need to comptime
+        const complex_apis = comptime try complex_types.generate(); // stage1: we need to comptime
         complex_alloc = bench.allocator(std.testing.allocator);
         var complex_arena = std.heap.ArenaAllocator.init(complex_alloc.allocator());
         defer complex_arena.deinit();
@@ -89,7 +89,7 @@ test {
     var multi_alloc: bench.Allocator = undefined;
     if (do_multi) {
         tests_nb += 1;
-        const multi_apis = comptime multiple_types.generate(); // stage1: we need to comptime
+        const multi_apis = comptime try multiple_types.generate(); // stage1: we need to comptime
         multi_alloc = bench.allocator(std.testing.allocator);
         var multi_arena = std.heap.ArenaAllocator.init(multi_alloc.allocator());
         defer multi_arena.deinit();
@@ -100,7 +100,7 @@ test {
     var cbk_alloc: bench.Allocator = undefined;
     if (do_cbk) {
         tests_nb += 1;
-        const cbk_apis = comptime callback.generate(); // stage1: we need comptime
+        const cbk_apis = comptime try callback.generate(); // stage1: we need comptime
         cbk_alloc = bench.allocator(std.testing.allocator);
         var cbk_arena = std.heap.ArenaAllocator.init(cbk_alloc.allocator());
         defer cbk_arena.deinit();

--- a/src/tests/cbk_test.zig
+++ b/src/tests/cbk_test.zig
@@ -47,8 +47,8 @@ pub const Window = struct {
 };
 
 // generate API, comptime
-pub fn generate() []jsruntime.API {
-    return jsruntime.compile(.{Window});
+pub fn generate() ![]jsruntime.API {
+    return try jsruntime.compile(.{Window});
 }
 
 // exec tests
@@ -72,7 +72,7 @@ pub fn exec(
     var cases_cbk_sync_without_arg = [_]tests.Case{
         // traditional anonymous function
         .{
-            .src = 
+            .src =
             \\let n = 1;
             \\function f() {n++};
             \\window.cbkSyncWithoutArg(f);
@@ -82,7 +82,7 @@ pub fn exec(
         .{ .src = "n;", .ex = "2" },
         // arrow function
         .{
-            .src = 
+            .src =
             \\let m = 1;
             \\window.cbkSyncWithoutArg(() => m++);
             ,
@@ -96,7 +96,7 @@ pub fn exec(
     var cases_cbk_sync_with_arg = [_]tests.Case{
         // traditional anonymous function
         .{
-            .src = 
+            .src =
             \\let x = 1;
             \\function f(a) {x = x + a};
             \\window.cbkSyncWithArg(f, 2);
@@ -106,7 +106,7 @@ pub fn exec(
         .{ .src = "x;", .ex = "3" },
         // arrow function
         .{
-            .src = 
+            .src =
             \\let y = 1;
             \\window.cbkSyncWithArg((a) => y = y + a, 2);
             ,
@@ -120,7 +120,7 @@ pub fn exec(
     var cases_cbk_async = [_]tests.Case{
         // traditional anonymous function
         .{
-            .src = 
+            .src =
             \\let o = 1;
             \\function f() {
             \\o++;
@@ -132,7 +132,7 @@ pub fn exec(
         },
         // arrow functional
         .{
-            .src = 
+            .src =
             \\let p = 1;
             \\window.cbkAsync(() => {
             \\p++;
@@ -148,7 +148,7 @@ pub fn exec(
     var cases_cbk_async_with_arg = [_]tests.Case{
         // traditional anonymous function
         .{
-            .src = 
+            .src =
             \\let i = 1;
             \\function f(a) {
             \\i = i + a;
@@ -160,7 +160,7 @@ pub fn exec(
         },
         // arrow functional
         .{
-            .src = 
+            .src =
             \\let j = 1;
             \\window.cbkAsyncWithArg((a) => {
             \\j = j + a;

--- a/src/tests/proto_test.zig
+++ b/src/tests/proto_test.zig
@@ -164,8 +164,8 @@ const UserProtoCast = struct {
 };
 
 // generate API, comptime
-pub fn generate() []public.API {
-    return public.compile(.{
+pub fn generate() ![]public.API {
+    return try public.compile(.{
         User,
         Person,
         PersonPtr,

--- a/src/tests/types_complex_test.zig
+++ b/src/tests/types_complex_test.zig
@@ -52,8 +52,12 @@ const MyVariadic = struct {
 };
 
 // generate API, comptime
-pub fn generate() []public.API {
-    return public.compile(.{ MyIterable, MyList, MyVariadic });
+pub fn generate() ![]public.API {
+    return try public.compile(.{
+        MyIterable,
+        MyList,
+        MyVariadic,
+    });
 }
 
 // exec tests

--- a/src/tests/types_multiple_test.zig
+++ b/src/tests/types_multiple_test.zig
@@ -60,8 +60,8 @@ const Computer = struct {
 };
 
 // generate API, comptime
-pub fn generate() []public.API {
-    return public.compile(.{ Windows, MacOS, Linux, Computer });
+pub fn generate() ![]public.API {
+    return try public.compile(.{ Windows, MacOS, Linux, Computer });
 }
 
 // exec tests

--- a/src/tests/types_native_test.zig
+++ b/src/tests/types_native_test.zig
@@ -177,8 +177,8 @@ const Country = struct {
 };
 
 // generate API, comptime
-pub fn generate() []public.API {
-    return public.compile(.{ Brand, Car, Country });
+pub fn generate() ![]public.API {
+    return try public.compile(.{ Brand, Car, Country });
 }
 
 // exec tests

--- a/src/tests/types_primitives_test.zig
+++ b/src/tests/types_primitives_test.zig
@@ -96,8 +96,8 @@ const Primitives = struct {
 };
 
 // generate API, comptime
-pub fn generate() []public.API {
-    return public.compile(.{Primitives});
+pub fn generate() ![]public.API {
+    return try public.compile(.{Primitives});
 }
 
 // exec tests


### PR DESCRIPTION
Instead of throwing a `@compileError` we return the error to the calling function.