### PR TITLE
Type under refacto

### DIFF
--- a/src/engines/v8/generate.zig
+++ b/src/engines/v8/generate.zig
@@ -77,7 +77,7 @@ fn getNativeArg(
     // JS Null or Undefined value
     if (js_value.isNull() or js_value.isUndefined()) {
         // if Native optional type return null
-        if (comptime arg_T.under_opt != null) {
+        if (comptime arg_T.underOpt() != null) {
             return null;
         }
         // TODO: else return error "Argument x is not an object"
@@ -89,7 +89,7 @@ fn getNativeArg(
         all_T,
         js_value.castTo(v8.Object),
     ) catch unreachable; // TODO: throw js exception
-    if (arg_T.under_ptr != null) {
+    if (arg_T.underPtr() != null) {
         value = ptr;
     } else {
         value = ptr.*;
@@ -175,7 +175,7 @@ fn getArgs(
         comptime var arg_real: refl.Type = undefined;
 
         comptime {
-            if (try refl.Type.variadic(arg.under_T())) |arg_v| {
+            if (try refl.Type.variadic(arg.underT())) |arg_v| {
                 arg_real = arg_v;
             } else {
                 arg_real = arg;
@@ -239,7 +239,7 @@ pub fn setNativeObject(
     js_obj: v8.Object,
     isolate: v8.Isolate,
 ) !void {
-    const T = obj_T.under_T();
+    const T = obj_T.underT();
 
     // assign and bind native obj to JS obj
     var obj_ptr: *T = undefined;
@@ -290,11 +290,12 @@ fn setReturnType(
     ctx: v8.Context,
     isolate: v8.Isolate,
 ) !v8.Value {
-    const val_T = if (ret.under_opt) |T| T else ret.T;
+    const under_opt = comptime ret.underOpt();
+    const val_T = if (under_opt) |T| T else ret.T;
     var val: val_T = undefined;
 
     // Optional
-    if (ret.under_opt != null) {
+    if (under_opt != null) {
         if (res == null) {
             // if null just return JS null
             return isolate.initNull().toValue();
@@ -372,7 +373,7 @@ fn setReturnType(
     // return is a builtin type
 
     const js_val = nativeToJS(
-        ret.under_T(),
+        ret.underT(),
         val,
         isolate,
     ) catch unreachable; // NOTE: should not happen has types have been checked at reflect

--- a/src/engines/v8/types_primitives.zig
+++ b/src/engines/v8/types_primitives.zig
@@ -75,7 +75,7 @@ pub fn jsToNative(
     // JS Null or Undefined value
     if (js_val.isNull() or js_val.isUndefined()) {
         // if Native optional type return null
-        if (comptime zig_T.under_opt != null) {
+        if (comptime zig_T.underOpt() != null) {
             return null;
         }
         // Here we should normally return an error
@@ -95,7 +95,7 @@ pub fn jsToNative(
         const js_obj = js_val.castTo(v8.Object);
         const nested_T = T_refl.nested[index];
         // using under_T to handle both mandatory and optional JS object
-        var obj: zig_T.under_T() = undefined;
+        var obj: zig_T.underT() = undefined;
         inline for (nested_T.fields) |field| {
             const name = field.name.?;
             const key = v8.String.initUtf8(isolate, name);
@@ -104,7 +104,7 @@ pub fn jsToNative(
                 const field_val = try jsToNative(alloc, T_refl, field, field_js_val, isolate, ctx);
                 @field(obj, name) = field_val;
             } else {
-                if (field.under_opt != null) {
+                if (comptime field.underOpt() != null) {
                     @field(obj, name) = null;
                 } else {
                     return error.JSWrongObject;
@@ -162,7 +162,7 @@ pub fn jsToNative(
         // integers unsigned
         u8, ?u8, u16, ?u16 => {
             const v = try js_val.toU32(ctx);
-            if (zig_T.under_opt) |under_opt| {
+            if (comptime zig_T.underOpt()) |under_opt| {
                 return @as(under_opt, @intCast(v));
             }
             return @as(zig_T.T, @intCast(v));


### PR DESCRIPTION
This refacto of the reflect `Type` has several purposes:
- make the logic of "underlying" type either in case of successive wrapping, in order to prepare the `ErrorUnion` case
-  use less (stack) memory (data oriented approach), by replacing fields in the struct `Type` by _comptime_ methods