### PR TITLE
env interface: add engine method

### DIFF
--- a/src/api.zig
+++ b/src/api.zig
@@ -50,3 +50,7 @@ pub const CallbackArg = Engine.CallbackArg;
 pub const TryCatch = Engine.TryCatch;
 pub const VM = Engine.VM;
 pub const Env = Engine.Env;
+
+pub const engineType = enum {
+    v8,
+};

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -77,6 +77,10 @@ pub const Env = struct {
 
     context: ?v8.Context = null,
 
+    pub fn engine() public.engineType {
+        return .v8;
+    }
+
     pub fn init(arena_alloc: *std.heap.ArenaAllocator, loop: *Loop) anyerror!Env {
 
         // globals values

--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -41,6 +41,9 @@ pub fn Env(
     comptime Object_T: type,
 ) void {
 
+    // engine()
+    assertDecl(T, "engine", fn () public.engineType);
+
     // init()
     assertDecl(T, "init", fn (
         arena_alloc: *std.heap.ArenaAllocator,


### PR DESCRIPTION
For some tests we need to know which kind of JS engine is used to deal with different implementations