### PR TITLE
update test to use allocator in a getter

### DIFF
--- a/src/tests/proto_test.zig
+++ b/src/tests/proto_test.zig
@@ -33,7 +33,10 @@ const Person = struct {
         return self.age;
     }
 
-    pub fn get_allocator(_: Person, _: std.mem.Allocator) bool {
+    pub fn get_allocator(_: Person, alloc: std.mem.Allocator) !bool {
+        const v = try alloc.alloc(u8, 10);
+        defer alloc.free(v);
+
         return true;
     }
 


### PR DESCRIPTION
The tests fail with my change:
```
$ make test
[36mTesting...[0m
run test: error: Reflect tests: OK
Segmentation fault at address 0x0
/usr/local/zig-0.11.0/lib/std/mem/Allocator.zig:86:29: 0x9f4738 in allocBytesWithAlignment__anon_26942 (test)
    return self.vtable.alloc(self.ptr, len, ptr_align, ret_addr);
                            ^
/usr/local/zig-0.11.0/lib/std/mem/Allocator.zig:211:40: 0x9d8a8a in allocWithSizeAndAlignment__anon_25622 (test)
    return self.allocBytesWithAlignment(alignment, byte_count, return_address);
                                       ^
/usr/local/zig-0.11.0/lib/std/mem/Allocator.zig:205:75: 0x9913d8 in alloc__anon_21616 (test)
    const ptr: [*]align(a) T = @ptrCast(try self.allocWithSizeAndAlignment(@sizeOf(T), a, n, return_address));
                                                                          ^
/home/pierre/wrk/jsruntime-lib/src/tests/proto_test.zig:37:34: 0xa152e8 in get_allocator (test)
        const v = try alloc.alloc(u8, 10);
                                 ^
/home/pierre/wrk/jsruntime-lib/src/engines/v8/generate.zig:518:13: 0x9f13e4 in getter (test)
            const res = @call(.auto, getter_func, args);
            ^
../../../../v8/src/api/api-arguments-inl.h:201:3: 0x169bbb0 in BasicCallNamedGetterCallback (../../../../v8/src/objects/objects.cc)
../../../../v8/src/api/api-arguments-inl.h:315:10: 0x1673777 in CallAccessorGetter (../../../../v8/src/objects/objects.cc)
../../../../v8/src/objects/objects.cc:1442:34: 0x1671d19 in GetPropertyWithAccessor (../../../../v8/src/objects/objects.cc)
../../../../v8/src/objects/objects.cc:1185:16: 0x1670843 in GetProperty (../../../../v8/src/objects/objects.cc)
../../../../v8/src/ic/ic.cc:507:5: 0x26e2528 in Load (../../../../v8/src/ic/ic.cc)
../../../../v8/src/ic/ic.cc:2675:3: 0x26f18ce in __RT_impl_Runtime_LoadNoFeedbackIC_Miss (../../../../v8/src/ic/ic.cc)
../../../../v8/src/ic/ic.cc:2660:1: 0x26f13f7 in Runtime_LoadNoFeedbackIC_Miss (../../../../v8/src/ic/ic.cc)
???:?:?: 0xfab5fe in ??? (???)
Unwind error at address `:0xfab5fe` (error.AddressOutOfRange), trace may be incomplete

???:?:?: 0x13e0a91 in ??? (???)
???:?:?: 0xc14e8d in ??? (???)
???:?:?: 0xc0d69b in ??? (???)
???:?:?: 0xc0d3c6 in ??? (???)
../../../../v8/src/execution/simulator.h:155:12: 0x1a1bcfa in Invoke (../../../../v8/src/execution/execution.cc)
../../../../v8/src/execution/execution.cc:538:10: 0x1a1cd7c in CallScript (../../../../v8/src/execution/execution.cc)
../../../../v8/src/api/api.cc:2272:7: 0xb5ab2d in Run (../../../../v8/src/api/api.cc)
/home/pierre/prs/brwsrcr/jsruntime-lib/vendor/zig-v8/src/binding.cpp:414:54: 0xa97363 in v8__Script__Run (/home/pierre/prs/brwsrcr/jsruntime-lib/vendor/zig-v8/src/binding.cpp)
/home/pierre/wrk/jsruntime-lib/vendor/zig-v8/src/v8.zig:1679:30: 0x990fbe in run (test)
        if (c.v8__Script__Run(self.handle, ctx.handle)) |value| {
                             ^
/home/pierre/wrk/jsruntime-lib/src/engines/v8/v8.zig:432:28: 0x991cc5 in exec (test)
        const res = scr.run(context) catch {
                           ^
/home/pierre/wrk/jsruntime-lib/src/engines/v8/v8.zig:311:21: 0x97922d in run (test)
        try res.exec(alloc, script, name, self.isolate, self.context.?, try_catch);
                    ^
/home/pierre/wrk/jsruntime-lib/src/tests/test_utils.zig:67:23: 0x978bfa in checkCases (test)
        try js_env.run(fba_alloc, case.src, name, &res, &cbk_res);
                      ^
/home/pierre/wrk/jsruntime-lib/src/tests/proto_test.zig:240:25: 0x979cf2 in exec__anon_12601 (test)
    try tests.checkCases(js_env, &cases2);
                        ^
/home/pierre/wrk/jsruntime-lib/src/engine.zig:47:18: 0x97ba3b in loadEnv__anon_12392 (test)
    try ctxExecFn(alloc, &js_env, apis);
                 ^
/home/pierre/wrk/jsruntime-lib/src/run_tests.zig:52:28: 0x985e21 in test_0 (test)
        _ = try eng.loadEnv(&proto_arena, proto.exec, proto_apis);
                           ^
/usr/local/zig-0.11.0/lib/test_runner.zig:100:29: 0x9a2919 in mainServer (test)
                test_fn.func() catch |err| switch (err) {
                            ^
/usr/local/zig-0.11.0/lib/test_runner.zig:34:26: 0x987c7a in main (test)
        return mainServer() catch @panic("internal test runner failure");
                         ^
/usr/local/zig-0.11.0/lib/std/start.zig:564:22: 0x9876d9 in main (test)
            root.main();
                     ^
run test: error: while executing test 'test_0', the following command terminated with signal 6 (expected exited with code 0):
/home/pierre/wrk/jsruntime-lib/zig-cache/o/a60c226cd95e207072a027264bbede17/test --listen=- 
Build Summary: 2/4 steps succeeded; 1 failed; 3/3 tests passed (disable with --summary none)
test transitive failure
+- run test failure
error: the following build command failed with exit code 1:
/home/pierre/wrk/jsruntime-lib/zig-cache/o/d0f1a847aab46fa419d11e06c6c79b9c/build /usr/local/zig-0.11.0/zig /home/pierre/wrk/jsruntime-lib /home/pierre/wrk/jsruntime-lib/zig-cache /home/pierre/.cache/zig test -Dengine=v8
[33mTest ERROR[0m
make: *** [Makefile:155: test] Error 1
```