### PR TITLE
bench: add a --json output option

### DIFF
--- a/src/main_bench.zig
+++ b/src/main_bench.zig
@@ -105,7 +105,7 @@ pub fn main() !void {
     defer vm.deinit();
 
     // allocators
-    var bench1 = bench.allocator(allocator);
+    var bench1 = bench.allocator(std.heap.page_allocator);
     var arena1 = std.heap.ArenaAllocator.init(bench1.allocator());
     defer arena1.deinit();
     var bench2 = bench.allocator(std.heap.page_allocator);


### PR DESCRIPTION
Relates to https://github.com/Browsercore/project/issues/91

```console
$ ./zig-out/bin/jsruntime-bench --json
[
  {
    "name": "With Isolate",
    "bench": {
      "duration": 1484587,
      "alloc_nb": 5,
      "realloc_nb": 491,
      "alloc_size": 86972
    }
  },
  {
    "name": "Without Isolate",
    "bench": {
      "duration": 757508,
      "alloc_nb": 4,
      "realloc_nb": 289,
      "alloc_size": 51466
    }
  }
]
```