### PR TITLE
Require a deinit function when allocator is used by an API

### DIFF
--- a/src/tests/proto_test.zig
+++ b/src/tests/proto_test.zig
@@ -82,6 +82,10 @@ const Person = struct {
     pub fn get_symbol_toStringTag(_: Person) []const u8 {
         return "MyPerson";
     }
+
+    pub fn deinit(self: *Person, alloc: std.mem.Allocator) void {
+        alloc.free(self.last_name);
+    }
 };
 
 const User = struct {
@@ -102,6 +106,10 @@ const User = struct {
 
     pub fn get_role(self: User) u8 {
         return self.role;
+    }
+
+    pub fn deinit(self: *User, alloc: std.mem.Allocator) void {
+        self.proto.deinit(alloc);
     }
 };
 
@@ -125,6 +133,10 @@ const PersonPtr = struct {
         const name_alloc = alloc.alloc(u8, name.len) catch unreachable;
         @memcpy(name_alloc, name);
         self.name = name_alloc;
+    }
+
+    pub fn deinit(self: *PersonPtr, alloc: std.mem.Allocator) void {
+        alloc.free(self.name);
     }
 };
 
@@ -174,6 +186,10 @@ const UserContainer = struct {
     pub fn _roleVal(self: UserForContainer) u8 {
         return self.role;
     }
+
+    pub fn deinit(self: *UserForContainer, alloc: std.mem.Allocator) void {
+        self.proto.deinit(alloc);
+    }
 };
 
 const PersonProtoCast = struct {
@@ -192,6 +208,10 @@ const PersonProtoCast = struct {
     pub fn get_name(self: PersonProtoCast) []const u8 {
         return self.first_name;
     }
+
+    pub fn deinit(self: *PersonProtoCast, alloc: std.mem.Allocator) void {
+        alloc.free(self.first_name);
+    }
 };
 
 const UserProtoCast = struct {
@@ -201,6 +221,10 @@ const UserProtoCast = struct {
 
     pub fn constructor(alloc: std.mem.Allocator, first_name: []u8) UserProtoCast {
         return .{ .not_proto = PersonProtoCast.constructor(alloc, first_name) };
+    }
+
+    pub fn deinit(self: *UserProtoCast, alloc: std.mem.Allocator) void {
+        self.not_proto.deinit(alloc);
     }
 };
 

--- a/src/tests/types_complex_test.zig
+++ b/src/tests/types_complex_test.zig
@@ -23,6 +23,10 @@ const MyList = struct {
     pub fn _symbol_iterator(self: MyList) MyIterable {
         return MyIterable.init(self.items);
     }
+
+    pub fn deinit(self: *MyList, alloc: std.mem.Allocator) void {
+        alloc.free(self.items);
+    }
 };
 
 const MyVariadic = struct {
@@ -49,6 +53,8 @@ const MyVariadic = struct {
     pub fn _empty(_: MyVariadic, _: ?VariadicBool) bool {
         return true;
     }
+
+    pub fn deinit(_: *MyVariadic, _: std.mem.Allocator) void {}
 };
 
 const MyErrorUnion = struct {
@@ -111,6 +117,8 @@ pub const MyException = struct {
             ErrorSet.MyCustomError => errorStrings(0),
         };
     }
+
+    pub fn deinit(_: *MyException, _: std.mem.Allocator) void {}
 };
 
 const MyTypeWithException = struct {

--- a/src/tests/types_native_test.zig
+++ b/src/tests/types_native_test.zig
@@ -25,6 +25,10 @@ const Brand = struct {
         @memcpy(name_alloc, name);
         self.name = name_alloc;
     }
+
+    pub fn deinit(self: *Brand, alloc: std.mem.Allocator) void {
+        alloc.free(self.name);
+    }
 };
 
 const Car = struct {
@@ -117,6 +121,10 @@ const Car = struct {
     // return *<Struct> in method
     pub fn _getBrandPtr(self: Car) *Brand {
         return self.get_brandPtr();
+    }
+
+    pub fn deinit(self: *Car, alloc: std.mem.Allocator) void {
+        alloc.destroy(self.brand_ptr);
     }
 };
 


### PR DESCRIPTION
If at least 1 function of the API has an allocator as argument we will required this API to have a deinit function.

NOTE: for now we don't call this deinit function
but the idea is to call it after the JS engine
has marked an object for garbage collection.

Relates to #111 
Relates to #62 