### PR TITLE
Fix free null optional case

### DIFF
--- a/src/engines/v8/generate.zig
+++ b/src/engines/v8/generate.zig
@@ -293,7 +293,10 @@ fn freeArgs(comptime func: refl.Func, obj: anytype) !void {
         if (arg_T.underT() == []u8 or arg_T.underT() == []const u8) {
             const val = @field(obj, arg_T.name.?);
             if (arg_T.underOpt() != null) {
-                utils.allocator.free(val.?);
+                // free only if val is non-null
+                if (val) |v| {
+                    utils.allocator.free(v);
+                }
             } else {
                 utils.allocator.free(val);
             }

--- a/src/tests/proto_test.zig
+++ b/src/tests/proto_test.zig
@@ -77,6 +77,8 @@ const Person = struct {
         self.age = age;
     }
 
+    pub fn _say(_: *Person, _: ?[]const u8) void {}
+
     // TODO: should be a static function
     // see https://github.com/Browsercore/jsruntime-lib/issues/127
     pub fn get_symbol_toStringTag(_: Person) []const u8 {
@@ -385,6 +387,14 @@ pub fn exec(
         .{ .src = "upc.name === 'Francis'", .ex = "true" },
     };
     try tests.checkCases(js_env, &casesProtoCast);
+
+    // free func arguments
+    var casesFreeArguments = [_]tests.Case{
+        .{ .src = "let dt = new Person('Deep', 'Thought', 7500000);", .ex = "undefined" },
+        .{ .src = "dt.say('42')", .ex = "undefined" },
+        .{ .src = "dt.say(null)", .ex = "undefined" },
+    };
+    try tests.checkCases(js_env, &casesFreeArguments);
 }
 
 fn intToStr(alloc: std.mem.Allocator, nb: u8) []const u8 {


### PR DESCRIPTION
Previously, we tried to free `null` arguments, generating a panic.