### PR TITLE
Add basic custom test runner

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -101,6 +101,7 @@ pub fn build(b: *std.Build) !void {
     });
     try common(tests, mode, options);
     tests.single_threaded = true;
+    tests.test_runner = "src/test_runner.zig";
     const run_tests = b.addRunArtifact(tests);
 
     // step

--- a/src/run_tests.zig
+++ b/src/run_tests.zig
@@ -18,7 +18,7 @@ const multiple_types = @import("tests/types_multiple_test.zig");
 const object_types = @import("tests/types_object.zig");
 const callback = @import("tests/cbk_test.zig");
 
-test {
+pub fn main() !void {
     std.debug.print("\n", .{});
 
     // reflect tests

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+const tests = @import("run_tests.zig");
+
+pub fn main() !void {
+    try tests.main();
+}


### PR DESCRIPTION
Rationale:

When you are in tests the `@import("root")` does not reference the _root_source_file_ but the test_runner itself, which prevents you to use this feature as the standard test_runner is not customizable.

And the standard test_runner has some problems, including some strange behavior with the type system, where the same `type` imported in the test_runner and in your code logic are not equals.

Solution:

We create our own very basic test_runner which basically only call the main function (and not the test function) of the test _root_source_file_.
Pros: it works :) And we are still using the `zig test` command, so `builtin.is_test` is still true.
Cons: we do not use the `test` function anymore but anyway we were already not really using it in the idiomatic way.