### PR TITLE
Implement a UserContext

### DIFF
--- a/src/api.zig
+++ b/src/api.zig
@@ -37,6 +37,8 @@ pub const Variadic = types.Variadic;
 pub const Loop = @import("loop.zig").SingleThreaded;
 pub const Console = @import("console.zig").Console;
 
+pub const UserContext = @import("user_context.zig").UserContext;
+
 // JS engine
 // ---------
 

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -10,11 +10,13 @@ const NativeContext = internal.NativeContext;
 const public = @import("api.zig");
 const Env = public.Env;
 const Loop = public.Loop;
+const UserContext = public.UserContext;
 
 pub const ContextExecFn = (fn (std.mem.Allocator, *Env) anyerror!void);
 
 pub fn loadEnv(
     arena_alloc: *std.heap.ArenaAllocator,
+    userctx: ?UserContext,
     comptime ctxExecFn: ContextExecFn,
 ) !void {
     const alloc = arena_alloc.allocator();
@@ -26,7 +28,7 @@ pub fn loadEnv(
     }
     var loop = try Loop.init(alloc);
     defer loop.deinit();
-    var js_env = try Env.init(alloc, &loop);
+    var js_env = try Env.init(alloc, &loop, userctx);
     defer js_env.deinit();
 
     // load APIs in JS env

--- a/src/engines/v8/generate.zig
+++ b/src/engines/v8/generate.zig
@@ -10,6 +10,7 @@ const NativeContext = internal.NativeContext;
 
 const public = @import("../../api.zig");
 const Loop = public.Loop;
+const UserContext = public.UserContext;
 
 const cbk = @import("callback.zig");
 const nativeToJS = @import("types_primitives.zig").nativeToJS;
@@ -194,6 +195,7 @@ fn getArg(
         value = switch (arg.T) {
             std.mem.Allocator => alloc,
             *Loop => nat_ctx.loop,
+            UserContext => nat_ctx.userctx orelse unreachable, // an arg requires a usercontext but it missing.
             cbk.Func, cbk.FuncSync, cbk.Arg => unreachable,
             JSObject => JSObject{ .nat_ctx = nat_ctx, .js_ctx = js_ctx, .js_obj = this },
             JSObjectID => JSObjectID.set(js_val.?.castTo(v8.Object)),

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -142,6 +142,11 @@ pub const Env = struct {
         self.nat_ctx.userctx = userctx;
     }
 
+    pub fn getUserContext(self: *Env) ?*public.UserContext {
+        if (self.nat_ctx.userctx) |*ctx| return ctx;
+        return null;
+    }
+
     // load user-defined Types into Javascript environement
     pub fn load(self: Env, js_types: []usize) anyerror!void {
         var tpls: [gen.Types.len]TPL = undefined;

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -136,15 +136,7 @@ pub const Env = struct {
     }
 
     pub fn setUserContext(self: *Env, userctx: public.UserContext) anyerror!void {
-        // you can't replace a user context defined in init.
-        if (self.nat_ctx.userctx != null) return error.UserContextExists;
-
         self.nat_ctx.userctx = userctx;
-    }
-
-    pub fn getUserContext(self: *Env) ?*public.UserContext {
-        if (self.nat_ctx.userctx) |*ctx| return ctx;
-        return null;
     }
 
     // load user-defined Types into Javascript environement

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -78,7 +78,11 @@ pub const Env = struct {
         return .v8;
     }
 
-    pub fn init(alloc: std.mem.Allocator, loop: *public.Loop) anyerror!Env {
+    pub fn init(
+        alloc: std.mem.Allocator,
+        loop: *public.Loop,
+        userctx: ?public.UserContext,
+    ) anyerror!Env {
 
         // v8 values
         // ---------
@@ -99,7 +103,7 @@ pub const Env = struct {
         const globals = v8.FunctionTemplate.initDefault(isolate);
 
         return Env{
-            .nat_ctx = try NativeContext.init(alloc, loop),
+            .nat_ctx = try NativeContext.init(alloc, loop, userctx),
             .isolate_params = params,
             .isolate = isolate,
             .hscope = hscope,
@@ -129,6 +133,13 @@ pub const Env = struct {
         self.nat_ctx.deinit();
 
         self.* = undefined;
+    }
+
+    pub fn setUserContext(self: *Env, userctx: public.UserContext) anyerror!void {
+        // you can't replace a user context defined in init.
+        if (self.nat_ctx.userctx != null) return error.UserContextExists;
+
+        self.nat_ctx.userctx = userctx;
     }
 
     // load user-defined Types into Javascript environement

--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -55,6 +55,8 @@ pub fn Env(
         userctx: public.UserContext,
     ) anyerror!void);
 
+    assertDecl(T, "getUserContext", fn (self: *T) ?*public.UserContext);
+
     // start()
     assertDecl(T, "start", fn (
         self: *T,

--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -40,7 +40,7 @@ pub fn Env(
     assertDecl(T, "engine", fn () public.engineType);
 
     // init()
-    assertDecl(T, "init", fn (alloc: std.mem.Allocator, loop: *public.Loop) anyerror!T);
+    assertDecl(T, "init", fn (alloc: std.mem.Allocator, loop: *public.Loop, userctx: ?public.UserContext) anyerror!T);
 
     // deinit()
     assertDecl(T, "deinit", fn (self: *T) void);
@@ -49,6 +49,11 @@ pub fn Env(
     assertDecl(T, "load", fn (self: T, js_types: []usize) anyerror!void);
 
     assertDecl(T, "bindGlobal", fn (self: T, ob: anytype) anyerror!void);
+
+    assertDecl(T, "setUserContext", fn (
+        self: *T,
+        userctx: public.UserContext,
+    ) anyerror!void);
 
     // start()
     assertDecl(T, "start", fn (

--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -55,8 +55,6 @@ pub fn Env(
         userctx: public.UserContext,
     ) anyerror!void);
 
-    assertDecl(T, "getUserContext", fn (self: *T) ?*public.UserContext);
-
     // start()
     assertDecl(T, "start", fn (
         self: *T,

--- a/src/main_bench.zig
+++ b/src/main_bench.zig
@@ -22,7 +22,7 @@ fn benchWithIsolate(
 ) !bench.Result {
     const duration = try bench.call(
         public.loadEnv,
-        .{ arena_alloc, ctxExecFn },
+        .{ arena_alloc, null, ctxExecFn },
         iter,
         warmup,
     );
@@ -58,7 +58,7 @@ fn benchWithoutIsolate(
             duration_global = duration;
         }
     };
-    try public.loadEnv(arena_alloc, s.do);
+    try public.loadEnv(arena_alloc, null, s.do);
     const alloc_stats = bench_alloc.stats();
     return bench.Result{
         .duration = duration_global,

--- a/src/native_context.zig
+++ b/src/native_context.zig
@@ -1,11 +1,13 @@
 const std = @import("std");
 
 const Loop = @import("api.zig").Loop;
+const UserContext = @import("api.zig").UserContext;
 const NatObjects = @import("internal_api.zig").refs.Map;
 
 pub const NativeContext = struct {
     alloc: std.mem.Allocator,
     loop: *Loop,
+    userctx: ?UserContext,
 
     js_objs: JSObjects,
     nat_objs: NatObjects,
@@ -17,11 +19,12 @@ pub const NativeContext = struct {
 
     pub const JSObjects = std.AutoHashMapUnmanaged(usize, usize);
 
-    pub fn init(alloc: std.mem.Allocator, loop: *Loop) !*NativeContext {
+    pub fn init(alloc: std.mem.Allocator, loop: *Loop, userctx: ?UserContext) !*NativeContext {
         const self = try alloc.create(NativeContext);
         self.* = .{
             .alloc = alloc,
             .loop = loop,
+            .userctx = userctx,
             .js_objs = JSObjects{},
             .nat_objs = NatObjects{},
         };

--- a/src/reflect.zig
+++ b/src/reflect.zig
@@ -9,6 +9,7 @@ const Callback = public.Callback;
 const CallbackSync = public.CallbackSync;
 const CallbackArg = public.CallbackArg;
 const JSObjectID = public.JSObjectID;
+const UserContext = public.UserContext;
 
 const JSObject = public.JSObject;
 
@@ -53,6 +54,7 @@ const internal_types = [_]type{
     CallbackSync,
     CallbackArg,
     JSObjectID,
+    UserContext,
 };
 
 fn isInternalType(comptime T: type) bool {
@@ -545,6 +547,11 @@ pub const Func = struct {
 
             // loop
             if (args_types[i].T == *Loop) {
+                index_offset += 1;
+            }
+
+            // user context
+            if (args_types[i].T == UserContext) {
                 index_offset += 1;
             }
 

--- a/src/run_tests.zig
+++ b/src/run_tests.zig
@@ -19,6 +19,7 @@ const multiple_types = @import("tests/types_multiple_test.zig");
 const object_types = @import("tests/types_object.zig");
 const callback = @import("tests/cbk_test.zig");
 const global = @import("tests/global_test.zig");
+const userctx = @import("tests/userctx_test.zig");
 
 // test to do
 const do_proto = true;
@@ -29,6 +30,7 @@ const do_multi = true;
 const do_obj = true;
 const do_cbk = true;
 const do_global = true;
+const do_userctx = true;
 
 // tests nb
 const tests_nb = blk: {
@@ -41,6 +43,7 @@ const tests_nb = blk: {
     if (do_obj) nb += 1;
     if (do_cbk) nb += 1;
     if (do_global) nb += 1;
+    if (do_userctx) nb += 1;
     break :blk nb;
 };
 
@@ -54,7 +57,10 @@ pub const Types = gen.reflect(gen.MergeTuple(.{
     object_types.Types,
     callback.Types,
     global.Types,
+    userctx.Types,
 }));
+
+pub const UserContext = userctx.UserContext;
 
 pub fn main() !void {
     std.debug.print("\n", .{});
@@ -78,7 +84,7 @@ pub fn main() !void {
         proto_alloc = bench.allocator(std.testing.allocator);
         var proto_arena = std.heap.ArenaAllocator.init(proto_alloc.allocator());
         defer proto_arena.deinit();
-        _ = try eng.loadEnv(&proto_arena, proto.exec);
+        _ = try eng.loadEnv(&proto_arena, null, proto.exec);
     }
 
     // primitive types tests
@@ -87,7 +93,7 @@ pub fn main() !void {
         prim_alloc = bench.allocator(std.testing.allocator);
         var prim_arena = std.heap.ArenaAllocator.init(prim_alloc.allocator());
         defer prim_arena.deinit();
-        _ = try eng.loadEnv(&prim_arena, primitive_types.exec);
+        _ = try eng.loadEnv(&prim_arena, null, primitive_types.exec);
     }
 
     // native types tests
@@ -96,7 +102,7 @@ pub fn main() !void {
         nat_alloc = bench.allocator(std.testing.allocator);
         var nat_arena = std.heap.ArenaAllocator.init(nat_alloc.allocator());
         defer nat_arena.deinit();
-        _ = try eng.loadEnv(&nat_arena, native_types.exec);
+        _ = try eng.loadEnv(&nat_arena, null, native_types.exec);
     }
 
     // complex types tests
@@ -105,7 +111,7 @@ pub fn main() !void {
         complex_alloc = bench.allocator(std.testing.allocator);
         var complex_arena = std.heap.ArenaAllocator.init(complex_alloc.allocator());
         defer complex_arena.deinit();
-        _ = try eng.loadEnv(&complex_arena, complex_types.exec);
+        _ = try eng.loadEnv(&complex_arena, null, complex_types.exec);
     }
 
     // multiple types tests
@@ -114,7 +120,7 @@ pub fn main() !void {
         multi_alloc = bench.allocator(std.testing.allocator);
         var multi_arena = std.heap.ArenaAllocator.init(multi_alloc.allocator());
         defer multi_arena.deinit();
-        _ = try eng.loadEnv(&multi_arena, multiple_types.exec);
+        _ = try eng.loadEnv(&multi_arena, null, multiple_types.exec);
     }
 
     // object types tests
@@ -123,7 +129,7 @@ pub fn main() !void {
         obj_alloc = bench.allocator(std.testing.allocator);
         var obj_arena = std.heap.ArenaAllocator.init(obj_alloc.allocator());
         defer obj_arena.deinit();
-        _ = try eng.loadEnv(&obj_arena, object_types.exec);
+        _ = try eng.loadEnv(&obj_arena, null, object_types.exec);
     }
 
     // callback tests
@@ -132,7 +138,7 @@ pub fn main() !void {
         cbk_alloc = bench.allocator(std.testing.allocator);
         var cbk_arena = std.heap.ArenaAllocator.init(cbk_alloc.allocator());
         defer cbk_arena.deinit();
-        _ = try eng.loadEnv(&cbk_arena, callback.exec);
+        _ = try eng.loadEnv(&cbk_arena, null, callback.exec);
     }
 
     // global tests
@@ -141,7 +147,16 @@ pub fn main() !void {
         global_alloc = bench.allocator(std.testing.allocator);
         var global_arena = std.heap.ArenaAllocator.init(global_alloc.allocator());
         defer global_arena.deinit();
-        _ = try eng.loadEnv(&global_arena, global.exec);
+        _ = try eng.loadEnv(&global_arena, null, global.exec);
+    }
+
+    // user context tests
+    var userctx_alloc: bench.Allocator = undefined;
+    if (do_userctx) {
+        userctx_alloc = bench.allocator(std.testing.allocator);
+        var userctx_arena = std.heap.ArenaAllocator.init(userctx_alloc.allocator());
+        defer userctx_arena.deinit();
+        _ = try eng.loadEnv(&userctx_arena, null, userctx.exec);
     }
 
     if (tests_nb == 0) {
@@ -232,6 +247,15 @@ pub fn main() !void {
             .value = global_alloc_stats.alloc_size,
         };
         try t.addRow(.{ "Global", global_alloc.alloc_nb, global_alloc_size });
+    }
+
+    if (do_userctx) {
+        const userctx_alloc_stats = global_alloc.stats();
+        const userctx_alloc_size = pretty.Measure{
+            .unit = "b",
+            .value = userctx_alloc_stats.alloc_size,
+        };
+        try t.addRow(.{ "User context", userctx_alloc.alloc_nb, userctx_alloc_size });
     }
 
     const out = std.io.getStdErr().writer();

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -263,7 +263,7 @@ pub fn shell(
     if (ctxExecFn) |func| {
         do_fn = func;
     }
-    try public.loadEnv(arena_alloc, do_fn);
+    try public.loadEnv(arena_alloc, null, do_fn);
 }
 
 fn repl() !void {

--- a/src/test_runner.zig
+++ b/src/test_runner.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const tests = @import("run_tests.zig");
 
 pub const Types = tests.Types;
+pub const UserContext = tests.UserContext;
 
 pub fn main() !void {
     try tests.main();

--- a/src/tests/userctx_test.zig
+++ b/src/tests/userctx_test.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+
+const public = @import("../api.zig");
+const tests = public.test_utils;
+
+const Config = struct {
+    use_proxy: bool,
+};
+
+pub const UserContext = Config;
+
+const Request = struct {
+    use_proxy: bool,
+
+    pub fn constructor(ctx: Config) Request {
+        return .{
+            .use_proxy = ctx.use_proxy,
+        };
+    }
+
+    pub fn get_proxy(self: *Request) bool {
+        return self.use_proxy;
+    }
+
+    pub fn _configProxy(_: *Request, ctx: Config) bool {
+        return ctx.use_proxy;
+    }
+};
+
+pub const Types = .{
+    Request,
+};
+
+// exec tests
+pub fn exec(
+    alloc: std.mem.Allocator,
+    js_env: *public.Env,
+) anyerror!void {
+    try js_env.setUserContext(Config{
+        .use_proxy = true,
+    });
+
+    // start JS env
+    try js_env.start(alloc);
+    defer js_env.stop();
+
+    var tc = [_]tests.Case{
+        .{ .src = "const req = new Request();", .ex = "undefined" },
+        .{ .src = "req.proxy", .ex = "true" },
+        .{ .src = "req.configProxy()", .ex = "true" },
+    };
+    try tests.checkCases(js_env, &tc);
+}

--- a/src/user_context.zig
+++ b/src/user_context.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+
+// UserContext is a type defined by the user optionally passed to the native
+// API.
+// The type is defined via a root declaration.
+// Request a UserContext parameter in your native implementation to get the
+// context.
+pub const UserContext = blk: {
+    const root = @import("root");
+    if (@hasDecl(root, "UserContext")) {
+        break :blk root.UserContext;
+    }
+
+    // when no declaration is given, UserContext is define with an empty struct.
+    break :blk struct {};
+};


### PR DESCRIPTION
lib user can now define a `root.UserContext` type.
If a `UserContext` is requested as func arg, it is passed by the lib.
    
By default the `UserContext` is set as an empty `struct{}`.

1. you must declare a `const UserContex = MyCtx` in root to be found by the lib
2. you can now request for `ctx: MyCtx` in your API implementation
3. set the `MyCtx` instance with `Env.init()` or `Env.setUserContext` (not both)

Fix #202 