### PR TITLE
callback: add a func.trycall and callback.Result

### DIFF
--- a/src/api.zig
+++ b/src/api.zig
@@ -65,6 +65,7 @@ pub const JSObjectID = Engine.JSObjectID;
 pub const Callback = Engine.Callback;
 pub const CallbackSync = Engine.CallbackSync;
 pub const CallbackArg = Engine.CallbackArg;
+pub const CallbackResult = Engine.CallbackResult;
 
 pub const TryCatch = Engine.TryCatch;
 pub const VM = Engine.VM;

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -28,6 +28,7 @@ const public = @import("../../api.zig");
 pub const Callback = @import("callback.zig").Func;
 pub const CallbackSync = @import("callback.zig").FuncSync;
 pub const CallbackArg = @import("callback.zig").Arg;
+pub const CallbackResult = @import("callback.zig").Result;
 
 pub const LoadFnType = @import("generate.zig").LoadFnType;
 pub const loadFn = @import("generate.zig").loadFn;

--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -157,21 +157,37 @@ pub fn TryCatch(comptime T: type, comptime env: type) void {
     ) callconv(.Inline) anyerror!?[]const u8);
 }
 
-pub fn Callback(comptime T: type) void {
+pub fn Callback(comptime T: type, comptime Res_T: type) void {
 
     // id()
     assertDecl(T, "id", fn (T: T) usize);
 
     // call()
     assertDecl(T, "call", fn (T: T, nat_args: anytype) anyerror!void);
+
+    // trycall()
+    assertDecl(T, "trycall", fn (T: T, nat_args: anytype, res: *Res_T) anyerror!void);
 }
 
-pub fn CallbackSync(comptime T: type) void {
+pub fn CallbackSync(comptime T: type, comptime Res_T: type) void {
     // call()
     assertDecl(T, "call", fn (T: T, alloc: std.mem.Allocator) anyerror!void);
+
+    // trycall()
+    assertDecl(T, "trycall", fn (T: T, alloc: std.mem.Allocator, res: *Res_T) anyerror!void);
 }
 
 pub fn CallbackArg(comptime _: type) void {}
+
+pub fn CallbackResult(comptime T: type) void {
+    // init()
+    assertDecl(T, "init", fn (alloc: std.mem.Allocator) T);
+
+    // deinit()
+    assertDecl(T, "deinit", fn (self: T) void);
+
+    // TODO: how to get the result?
+}
 
 // Utils
 // -----

--- a/src/private_api.zig
+++ b/src/private_api.zig
@@ -21,8 +21,9 @@ fn checkInterfaces(engine: anytype) void {
     // public api
     interfaces.API(engine.API, engine.LoadFnType);
 
-    interfaces.Callback(engine.Callback);
-    interfaces.CallbackSync(engine.CallbackSync);
+    interfaces.CallbackResult(engine.CallbackResult);
+    interfaces.Callback(engine.Callback, engine.CallbackResult);
+    interfaces.CallbackSync(engine.CallbackSync, engine.CallbackResult);
     interfaces.CallbackArg(engine.CallbackArg);
 
     interfaces.JSResult(engine.JSResult);


### PR DESCRIPTION
Give a way to get the callback result.
* [x] create a `callback.Result` similar to `JSResult`
* [x] add a `Func.trycall` method to get the result

relates with https://github.com/lightpanda-io/browsercore/issues/224 