### PR TITLE
ci: add --security-opt seccomp=unconfined docker option

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,6 +45,11 @@ jobs:
        username: ${{ github.actor }}
        password: ${{ secrets.GITHUB_TOKEN }}
 
+      # docker blocks io_uring syscalls by default now.
+      # see https://github.com/tigerbeetle/tigerbeetle/pull/1995
+      # see https://github.com/moby/moby/pull/46762
+      options: "--security-opt seccomp=unconfined"
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/zig-test.yml
+++ b/.github/workflows/zig-test.yml
@@ -107,6 +107,11 @@ jobs:
        username: ${{ github.actor }}
        password: ${{ secrets.GITHUB_TOKEN }}
 
+      # docker blocks io_uring syscalls by default now.
+      # see https://github.com/tigerbeetle/tigerbeetle/pull/1995
+      # see https://github.com/moby/moby/pull/46762
+      options: "--security-opt seccomp=unconfined"
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/zig-test.yml
+++ b/.github/workflows/zig-test.yml
@@ -11,6 +11,7 @@ on:
       - "src/**/*.zig"
       - "src/*.zig"
       - "*.zig"
+      - ".github/**"
   pull_request:
 
     # By default GH trigger on types opened, synchronize and reopened.
@@ -26,6 +27,7 @@ on:
       - "src/**/*.zig"
       - "src/*.zig"
       - "*.zig"
+      - ".github/**"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
It seems docker blocks io_uring by default using seccomp.

see https://github.com/tigerbeetle/tigerbeetle/pull/1995 and
https://github.com/moby/moby/pull/46762

fix #232