### PR TITLE
callback: handle callback parameter on constructor

### DIFF
--- a/src/engines/v8/generate.zig
+++ b/src/engines/v8/generate.zig
@@ -976,8 +976,15 @@ fn callFunc(
     // sync callback
     // for test purpose, does not have any sense in real case
     if (comptime func.callback_index != null) {
-        // -1 because of self
-        const js_func_index = func.callback_index.? - func.index_offset - 1;
+        const js_func_index = comptime brk: {
+            var idx = func.callback_index.? - func.index_offset;
+
+            // -1 because of self
+            if (func.kind != .constructor) idx -= 1;
+
+            break :brk idx;
+        };
+
         if (func.args[js_func_index].T == cbk.FuncSync) {
             args[func.callback_index.? - func.index_offset].call(nat_ctx.alloc) catch unreachable;
         }

--- a/src/reflect.zig
+++ b/src/reflect.zig
@@ -488,6 +488,8 @@ pub const Func = struct {
 
     setter_index: ?u8, // TODO: not ideal, is there a cleaner solution?
 
+    kind: FuncKind,
+
     fn lookupTypes(comptime self: *Func, comptime structs: []const Struct) Error!void {
         // copy args
         var args: [self.args.len]Type = undefined;
@@ -707,6 +709,8 @@ pub const Func = struct {
             .symbol = Symbol.reflect(name),
 
             .setter_index = null,
+
+            .kind = kind,
         };
     }
 };


### PR DESCRIPTION
Adding a `Callback` parameter on a constructor failed with:
```console
$ zig build                                                                                                                                  
install                                                                                                                                      
└─ install browsercore                                                                                                                       
   └─ zig build-exe browsercore Debug native 1 errors                                                                                        
vendor/zig-js-runtime/src/engines/v8/generate.zig:980:73: error: overflow of integer type 'usize' with value '-1'                            
        const js_func_index = func.callback_index.? - func.index_offset - 1;                                                                 
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~                                                                                                                                                                                                               
referenced by:                                                                                                                               
    constructor: vendor/zig-js-runtime/src/engines/v8/generate.zig:999:21                                                                    
    generateConstructor__anon_19702: vendor/zig-js-runtime/src/engines/v8/generate.zig:1007:6                                                
    remaining reference traces hidden; use '-freference-trace' to see all reference traces                                                   
 ```
 
 This PR:
 * adds a `kind` to `Func` struct
 * uses `kind` to fix callback offset creation