### PR TITLE
Refacto Env JS execution and result

### DIFF
--- a/src/api.zig
+++ b/src/api.zig
@@ -41,6 +41,17 @@ pub const test_utils = @import("tests/test_utils.zig");
 // JS types
 // --------
 
+pub const JSTypes = enum {
+    object,
+    function,
+    string,
+    number,
+    boolean,
+    bigint,
+    null,
+    undefined,
+};
+
 const types = @import("types.zig");
 pub const i64Num = types.i64Num;
 pub const u64Num = types.u64Num;

--- a/src/api.zig
+++ b/src/api.zig
@@ -59,7 +59,7 @@ pub const UserContext = @import("user_context.zig").UserContext;
 
 const Engine = @import("private_api.zig").Engine;
 
-pub const JSResult = Engine.JSResult;
+pub const JSValue = Engine.JSValue;
 pub const JSObject = Engine.JSObject;
 pub const JSObjectID = Engine.JSObjectID;
 

--- a/src/engines/v8/callback.zig
+++ b/src/engines/v8/callback.zig
@@ -367,7 +367,7 @@ pub const Func = struct {
         // execute function
         const result = js_func.call(js_ctx, this, args);
         if (result == null) {
-            return error.JSCallback;
+            return error.JSExecCallback;
         }
     }
 };

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -422,6 +422,7 @@ pub const JSObject = struct {
 pub const JSValue = struct {
     value: v8.Value,
 
+    // the caller needs to deinit the string returned
     pub fn toString(self: JSValue, alloc: std.mem.Allocator, env: Env) anyerror![]const u8 {
         return valueToUtf8(alloc, self.value, env.isolate, env.js_ctx.?);
     }

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -438,6 +438,7 @@ pub const TryCatch = struct {
         return self.inner.hasCaught();
     }
 
+    // the caller needs to deinit the string returned
     pub fn exception(self: TryCatch, alloc: std.mem.Allocator, env: Env) anyerror!?[]const u8 {
         if (self.inner.getException()) |msg| {
             return try valueToUtf8(alloc, msg, env.isolate, env.js_ctx.?);
@@ -445,6 +446,7 @@ pub const TryCatch = struct {
         return null;
     }
 
+    // the caller needs to deinit the string returned
     pub fn stack(self: TryCatch, alloc: std.mem.Allocator, env: Env) anyerror!?[]const u8 {
         const stck = self.inner.getStackTrace(env.js_ctx.?);
         if (stck) |s| return try valueToUtf8(alloc, s, env.isolate, env.js_ctx.?);

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -466,6 +466,18 @@ pub const TryCatch = struct {
         return null;
     }
 
+    // a shorthand method to return either the entire stack message
+    // or just the exception message
+    // - in Debug mode return the stack if available
+    // - otherwhise return the exception if available
+    // the caller needs to deinit the string returned
+    pub fn err(self: TryCatch, alloc: std.mem.Allocator, env: Env) anyerror!?[]const u8 {
+        if (builtin.mode == .Debug) {
+            if (try self.stack(alloc, env)) |msg| return msg;
+        }
+        return try self.exception(alloc, env);
+    }
+
     pub fn deinit(self: *TryCatch) void {
         self.inner.deinit();
     }

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -426,6 +426,18 @@ pub const JSValue = struct {
     pub fn toString(self: JSValue, alloc: std.mem.Allocator, env: Env) anyerror![]const u8 {
         return valueToUtf8(alloc, self.value, env.isolate, env.js_ctx.?);
     }
+
+    pub fn typeOf(self: JSValue, env: Env) anyerror!public.JSTypes {
+        var buf: [20]u8 = undefined;
+        const str = try self.value.typeOf(env.isolate);
+        const len = str.lenUtf8(env.isolate);
+        const s = buf[0..len];
+        _ = str.writeUtf8(env.isolate, s);
+        return std.meta.stringToEnum(public.JSTypes, s) orelse {
+            std.log.err("JSValueTypeNotHandled: {s}", .{s});
+            return error.JSValueTypeNotHandled;
+        };
+    }
 };
 
 pub const TryCatch = struct {

--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -116,6 +116,9 @@ pub fn JSValue(comptime T: type, env: type) void {
 
     // toString()
     assertDecl(T, "toString", fn (self: T, alloc: std.mem.Allocator, env: env) anyerror![]const u8);
+
+    // typeOf()
+    assertDecl(T, "typeOf", fn (self: T, env: env) anyerror!public.JSTypes);
 }
 
 pub fn JSObjectID(comptime T: type) void {

--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -145,6 +145,13 @@ pub fn TryCatch(comptime T: type, comptime env: type) void {
         env: env,
     ) anyerror!?[]const u8);
 
+    // err()
+    assertDecl(T, "err", fn (
+        self: T,
+        alloc: std.mem.Allocator,
+        env: env,
+    ) anyerror!?[]const u8);
+
     // stack()
     assertDecl(T, "stack", fn (
         self: T,

--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -46,7 +46,7 @@ pub fn VM(comptime T: type) void {
 
 pub fn Env(
     comptime T: type,
-    comptime JSResult_T: type,
+    comptime JSValue_T: type,
     comptime Object_T: type,
 ) void {
 
@@ -70,10 +70,7 @@ pub fn Env(
     ) anyerror!void);
 
     // start()
-    assertDecl(T, "start", fn (
-        self: *T,
-        alloc: std.mem.Allocator,
-    ) anyerror!void);
+    assertDecl(T, "start", fn (self: *T) anyerror!void);
 
     // stop()
     assertDecl(T, "stop", fn (self: *T) void);
@@ -97,42 +94,32 @@ pub fn Env(
         to_obj: ?Object_T,
     ) anyerror!void);
 
-    // TODO: check exec, wait who have v8 specific params
-
-    // waitTryCatch
-    assertDecl(T, "waitTryCatch", fn (
+    // exec() executes script in JS
+    assertDecl(T, "exec", fn (
         self: T,
-        alloc: std.mem.Allocator,
-    ) anyerror!JSResult_T);
-
-    // execTryCatch() executes script in JS
-    assertDecl(T, "execTryCatch", fn (
-        self: T,
-        alloc: std.mem.Allocator,
         script: []const u8,
         name: ?[]const u8,
-    ) anyerror!JSResult_T);
+    ) anyerror!JSValue_T);
 
-    // run() executes script in JS and waits all JS callbacks
-    assertDecl(T, "run", fn (
+    // wait() all JS callbacks
+    assertDecl(T, "wait", fn (
         self: T,
-        alloc: std.mem.Allocator,
-        script: []const u8,
-        name: ?[]const u8,
-        res: *JSResult_T,
-        cbk_res: ?*JSResult_T,
+        ignore_errors: bool,
     ) anyerror!void);
+
+    // execWait() executes script in JS and waits all JS callbacks
+    assertDecl(T, "execWait", fn (
+        self: T,
+        script: []const u8,
+        name: ?[]const u8,
+        ignore_errors: bool,
+    ) anyerror!JSValue_T);
 }
 
-pub fn JSResult(comptime T: type) void {
+pub fn JSValue(comptime T: type, env: type) void {
 
-    // init()
-    assertDecl(T, "init", fn () T);
-
-    // deinit()
-    assertDecl(T, "deinit", fn (self: T, alloc: std.mem.Allocator) void);
-
-    // TODO: how to get the result?
+    // toString()
+    assertDecl(T, "toString", fn (self: T, alloc: std.mem.Allocator, env: env) anyerror![]const u8);
 }
 
 pub fn JSObjectID(comptime T: type) void {
@@ -144,17 +131,27 @@ pub fn JSObjectID(comptime T: type) void {
 pub fn TryCatch(comptime T: type, comptime env: type) void {
 
     // init()
-    assertDecl(T, "init", fn (env: env) callconv(.Inline) T);
+    assertDecl(T, "init", fn (self: *T, env: env) void);
 
     // deinit()
-    assertDecl(T, "deinit", fn (self: *T) callconv(.Inline) void);
+    assertDecl(T, "deinit", fn (self: *T) void);
 
-    // exception
+    // hasCaught()
+    assertDecl(T, "hasCaught", fn (self: T) bool);
+
+    // exception()
     assertDecl(T, "exception", fn (
         self: T,
         alloc: std.mem.Allocator,
         env: env,
-    ) callconv(.Inline) anyerror!?[]const u8);
+    ) anyerror!?[]const u8);
+
+    // stack()
+    assertDecl(T, "stack", fn (
+        self: T,
+        alloc: std.mem.Allocator,
+        env: env,
+    ) anyerror!?[]const u8);
 }
 
 pub fn Callback(comptime T: type, comptime Res_T: type) void {

--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -102,17 +102,13 @@ pub fn Env(
     ) anyerror!JSValue_T);
 
     // wait() all JS callbacks
-    assertDecl(T, "wait", fn (
-        self: T,
-        ignore_errors: bool,
-    ) anyerror!void);
+    assertDecl(T, "wait", fn (self: T) anyerror!void);
 
     // execWait() executes script in JS and waits all JS callbacks
     assertDecl(T, "execWait", fn (
         self: T,
         script: []const u8,
         name: ?[]const u8,
-        ignore_errors: bool,
     ) anyerror!JSValue_T);
 }
 

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -67,6 +67,10 @@ pub const SingleThreaded = struct {
             try self.io.tick();
             // at each iteration we might have new events registred by previous callbacks
         }
+        // TODO: return instead immediatly on the first JS callback error
+        // and let the caller decide what to do next
+        // (typically retrieve the exception through the TryCatch and
+        // continue the execution of callbacks with a new call to loop.run)
         if (self.cbk_error) {
             return error.JSExecCallback;
         }

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -68,7 +68,7 @@ pub const SingleThreaded = struct {
             // at each iteration we might have new events registred by previous callbacks
         }
         if (self.cbk_error) {
-            return error.JSCallback;
+            return error.JSExecCallback;
         }
     }
 

--- a/src/private_api.zig
+++ b/src/private_api.zig
@@ -26,7 +26,7 @@ fn checkInterfaces(engine: anytype) void {
     interfaces.CallbackSync(engine.CallbackSync, engine.CallbackResult);
     interfaces.CallbackArg(engine.CallbackArg);
 
-    interfaces.JSResult(engine.JSResult);
+    interfaces.JSValue(engine.JSValue, engine.Env);
     interfaces.JSObjectID(engine.JSObjectID);
 
     interfaces.TryCatch(engine.TryCatch, engine.Env);
@@ -34,7 +34,7 @@ fn checkInterfaces(engine: anytype) void {
     interfaces.VM(engine.VM);
     interfaces.Env(
         engine.Env,
-        engine.JSResult,
+        engine.JSValue,
         engine.Object,
     );
 

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -159,6 +159,7 @@ fn cmdCallback(
 
     // JS print result
     const s = res.toString(ctx.alloc, ctx.js_env.*) catch unreachable;
+    defer ctx.alloc.free(s);
     if (std.mem.eql(u8, s, "undefined")) {
         printStdout("<- \x1b[38;5;242m{s}\x1b[0m\n", .{s});
     } else {

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -105,7 +105,7 @@ const CmdContext = struct {
     buf: []u8,
     close: bool = false,
 
-    try_catch: public.TryCatch,
+    try_catch: *public.TryCatch,
 };
 
 // I/O input command callback
@@ -128,42 +128,40 @@ fn cmdCallback(
         return;
     }
 
-    // JS execute
-    const res = ctx.js_env.exec(
-        ctx.alloc,
-        input,
-        "shell.js",
-        ctx.try_catch,
-    ) catch |err| {
-        ctx.close = true;
-        std.debug.print("JS exec error: {s}\n", .{@errorName(err)});
-        return;
-    };
-    defer res.deinit(ctx.alloc);
+    defer {
 
-    // JS print result
-    if (res.success) {
-        if (std.mem.eql(u8, res.result, "undefined")) {
-            printStdout("<- \x1b[38;5;242m{s}\x1b[0m\n", .{res.result});
-        } else {
-            printStdout("<- \x1b[33m{s}\x1b[0m\n", .{res.result});
-        }
-    } else {
-        printStdout("{s}\n", .{res.result});
+        // acknowledge to repl result has been printed
+        _ = std.posix.write(ctx.socket, "ok") catch unreachable;
+
+        // continue receving messages asynchronously
+        ctx.js_env.nat_ctx.loop.io.recv(
+            *CmdContext,
+            ctx,
+            cmdCallback,
+            completion,
+            ctx.socket,
+            ctx.buf,
+        );
     }
 
-    // acknowledge to repl result has been printed
-    _ = std.posix.write(ctx.socket, "ok") catch unreachable;
+    // JS execute
+    const res = ctx.js_env.exec(
+        input,
+        "shell.js",
+    ) catch {
+        const except = ctx.try_catch.exception(ctx.alloc, ctx.js_env.*) catch unreachable;
+        defer ctx.alloc.free(except.?);
+        printStdout("\x1b[38;5;242mUncaught {s}\x1b[0m\n", .{except.?});
+        return;
+    };
 
-    // continue receving messages asynchronously
-    ctx.js_env.nat_ctx.loop.io.recv(
-        *CmdContext,
-        ctx,
-        cmdCallback,
-        completion,
-        ctx.socket,
-        ctx.buf,
-    );
+    // JS print result
+    const s = res.toString(ctx.alloc, ctx.js_env.*) catch unreachable;
+    if (std.mem.eql(u8, s, "undefined")) {
+        printStdout("<- \x1b[38;5;242m{s}\x1b[0m\n", .{s});
+    } else {
+        printStdout("<- \x1b[33m{s}\x1b[0m\n", .{s});
+    }
 }
 
 fn exec(
@@ -172,7 +170,7 @@ fn exec(
 ) anyerror!void {
 
     // start JS env
-    try js_env.start(alloc);
+    try js_env.start();
     defer js_env.stop();
 
     try shellExec(alloc, js_env);
@@ -191,7 +189,8 @@ pub fn shellExec(
     try js_env.addObject(console, "console");
 
     // JS try cache
-    var try_catch = public.TryCatch.init(js_env.*);
+    var try_catch: public.TryCatch = undefined;
+    try_catch.init(js_env.*);
     defer try_catch.deinit();
 
     // create I/O contexts and callbacks
@@ -202,7 +201,7 @@ pub fn shellExec(
         .js_env = js_env,
         .socket = undefined,
         .buf = &input,
-        .try_catch = try_catch,
+        .try_catch = &try_catch,
     };
     var conn_ctx = ConnContext{
         .socket = socket_fd,
@@ -227,8 +226,8 @@ pub fn shellExec(
         try loop.io.tick();
         if (loop.cbk_error) {
             if (try try_catch.exception(alloc, js_env.*)) |msg| {
-                printStdout("\n\rUncaught {s}\n\r", .{msg});
-                alloc.free(msg);
+                defer alloc.free(msg);
+                printStdout("\x1b[38;5;242mUncaught {s}\x1b[0m\n", .{msg});
             }
             loop.cbk_error = false;
         }

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -150,8 +150,10 @@ fn cmdCallback(
         "shell.js",
     ) catch {
         const except = ctx.try_catch.exception(ctx.alloc, ctx.js_env.*) catch unreachable;
-        defer ctx.alloc.free(except.?);
-        printStdout("\x1b[38;5;242mUncaught {s}\x1b[0m\n", .{except.?});
+        if (except) |msg| {
+            defer ctx.alloc.free(msg);
+            printStdout("\x1b[38;5;242mUncaught {s}\x1b[0m\n", .{msg});
+        }
         return;
     };
 

--- a/src/tests/cbk_test.zig
+++ b/src/tests/cbk_test.zig
@@ -89,12 +89,12 @@ pub const Types = .{
 
 // exec tests
 pub fn exec(
-    alloc: std.mem.Allocator,
+    _: std.mem.Allocator,
     js_env: *jsruntime.Env,
 ) anyerror!void {
 
     // start JS env
-    try js_env.start(alloc);
+    try js_env.start();
     defer js_env.stop();
 
     // constructor

--- a/src/tests/global_test.zig
+++ b/src/tests/global_test.zig
@@ -41,12 +41,12 @@ pub const Types = .{
 
 // exec tests
 pub fn exec(
-    alloc: std.mem.Allocator,
+    _: std.mem.Allocator,
     js_env: *public.Env,
 ) anyerror!void {
 
     // start JS env
-    try js_env.start(alloc);
+    try js_env.start();
     defer js_env.stop();
 
     // global

--- a/src/tests/proto_test.zig
+++ b/src/tests/proto_test.zig
@@ -261,7 +261,7 @@ pub fn exec(
 ) anyerror!void {
 
     // start JS env
-    try js_env.start(alloc);
+    try js_env.start();
     defer js_env.stop();
 
     const ownBase = tests.engineOwnPropertiesDefault();

--- a/src/tests/test_utils.zig
+++ b/src/tests/test_utils.zig
@@ -100,7 +100,7 @@ pub fn checkCasesAlloc(allocator: std.mem.Allocator, js_env: *public.Env, cases:
         const name = try std.fmt.bufPrint(buf[0..], "test_{d}.js", .{test_case});
 
         // run script error
-        const res = js_env.execWait(case.src, name, false) catch |err| {
+        const res = js_env.execWait(case.src, name) catch |err| {
 
             // is it an intended error?
             const except = try try_catch.exception(alloc, js_env.*);

--- a/src/tests/test_utils.zig
+++ b/src/tests/test_utils.zig
@@ -128,6 +128,7 @@ pub fn checkCasesAlloc(allocator: std.mem.Allocator, js_env: *public.Env, cases:
 
         // check if result is expected
         const res_string = try res.toString(alloc, js_env.*);
+        defer alloc.free(res_string);
         const equal = std.mem.eql(u8, case.ex, res_string);
         if (!equal) {
             has_error = true;

--- a/src/tests/types_complex_test.zig
+++ b/src/tests/types_complex_test.zig
@@ -186,12 +186,12 @@ pub const Types = .{
 
 // exec tests
 pub fn exec(
-    alloc: std.mem.Allocator,
+    _: std.mem.Allocator,
     js_env: *public.Env,
 ) anyerror!void {
 
     // start JS env
-    try js_env.start(alloc);
+    try js_env.start();
     defer js_env.stop();
 
     var iter = [_]tests.Case{

--- a/src/tests/types_multiple_test.zig
+++ b/src/tests/types_multiple_test.zig
@@ -82,12 +82,12 @@ pub const Types = .{
 
 // exec tests
 pub fn exec(
-    alloc: std.mem.Allocator,
+    _: std.mem.Allocator,
     js_env: *public.Env,
 ) anyerror!void {
 
     // start JS env
-    try js_env.start(alloc);
+    try js_env.start();
     defer js_env.stop();
 
     var cases = [_]tests.Case{

--- a/src/tests/types_native_test.zig
+++ b/src/tests/types_native_test.zig
@@ -241,12 +241,12 @@ pub const Types = .{
 
 // exec tests
 pub fn exec(
-    alloc: std.mem.Allocator,
+    _: std.mem.Allocator,
     js_env: *public.Env,
 ) anyerror!void {
 
     // start JS env
-    try js_env.start(alloc);
+    try js_env.start();
     defer js_env.stop();
 
     var nested_arg = [_]tests.Case{

--- a/src/tests/types_object.zig
+++ b/src/tests/types_object.zig
@@ -90,7 +90,7 @@ pub fn exec(
 ) anyerror!void {
 
     // start JS env
-    try js_env.start(alloc);
+    try js_env.start();
     defer js_env.stop();
 
     // const o = Other{ .val = 4 };

--- a/src/tests/types_primitives_test.zig
+++ b/src/tests/types_primitives_test.zig
@@ -115,12 +115,12 @@ pub const Types = .{
 
 // exec tests
 pub fn exec(
-    alloc: std.mem.Allocator,
+    _: std.mem.Allocator,
     js_env: *public.Env,
 ) anyerror!void {
 
     // start JS env
-    try js_env.start(alloc);
+    try js_env.start();
     defer js_env.stop();
 
     // constructor

--- a/src/tests/userctx_test.zig
+++ b/src/tests/userctx_test.zig
@@ -33,7 +33,7 @@ pub const Types = .{
 
 // exec tests
 pub fn exec(
-    alloc: std.mem.Allocator,
+    _: std.mem.Allocator,
     js_env: *public.Env,
 ) anyerror!void {
     try js_env.setUserContext(Config{
@@ -41,7 +41,7 @@ pub fn exec(
     });
 
     // start JS env
-    try js_env.start(alloc);
+    try js_env.start();
     defer js_env.stop();
 
     var tc = [_]tests.Case{


### PR DESCRIPTION
- return a JSValue instead of a JSResult, preserving the underlying value and avoiding automatic stringification (with allocation)
- let the caller handle TryCatch if needed, including retreiving exception and stack if needed
- refacto the TryCatch interface to hide v8 implementation from the public implementation
- simplify the Env related methods (exec + execWait)
- do not close shell on JS exec error