### PR TITLE
Clean up engine selection

### DIFF
--- a/src/api.zig
+++ b/src/api.zig
@@ -87,6 +87,6 @@ pub const Inspector = Engine.Inspector;
 pub const InspectorOnResponseFn = *const fn (ctx: *anyopaque, call_id: u32, msg: []const u8) void;
 pub const InspectorOnEventFn = *const fn (ctx: *anyopaque, msg: []const u8) void;
 
-pub const engineType = enum {
+pub const EngineType = enum {
     v8,
 };

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -90,7 +90,7 @@ pub const Env = struct {
 
     js_ctx: ?v8.Context = null,
 
-    pub fn engine() public.engineType {
+    pub fn engine() public.EngineType {
         return .v8;
     }
 

--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -52,7 +52,7 @@ pub fn Env(
 ) void {
 
     // engine()
-    assertDecl(T, "engine", fn () public.engineType);
+    assertDecl(T, "engine", fn () public.EngineType);
 
     // init()
     assertDecl(T, "init", fn (self: *T, alloc: std.mem.Allocator, loop: *public.Loop, userctx: ?public.UserContext) void);

--- a/src/private_api.zig
+++ b/src/private_api.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 
+const build_opts = @import("jsruntime_build_options");
 const interfaces = @import("interfaces.zig");
 
 fn checkInterfaces(engine: anytype) void {
@@ -44,31 +45,13 @@ fn checkInterfaces(engine: anytype) void {
     // private api
 }
 
-pub const Engine = blk: {
-
-    // retrieve JS engine
-
-    // - as a build option
-    const build_opts = @import("jsruntime_build_options");
-    if (@hasDecl(build_opts, "engine")) {
-        // use v8 by default.
-        const eng = build_opts.engine orelse "v8";
-        if (std.mem.eql(u8, eng, "v8")) {
-            const engine = @import("engines/v8/v8.zig");
-            checkInterfaces(engine);
-            break :blk engine;
-        }
-        @compileError("unknwon -Dengine '" ++ eng ++ "'");
-    }
-
-    // - as a root declaration
-    const root = @import("root");
-    if (@hasDecl(root, "JSEngine")) {
-        checkInterfaces(root.JSEngine);
-        break :blk root.JSEngine;
-    }
-
-    @compileError("you need to specify a JS engine as a build option (-Dengine) or as a root file declaration (pub const JSEngine)");
+// retrieve JS engine
+pub const Engine = switch (build_opts.engine) {
+    .v8 => blk: {
+        const engine = @import("engines/v8/v8.zig");
+        checkInterfaces(engine);
+        break :blk engine;
+    },
 };
 
 pub const API = Engine.API;


### PR DESCRIPTION
Lots of issues here:

- Engine enum is duplicated for no reason
- The Zig build system supports passing an enum type to options natively, with much nicer output:

  ```
  error: Expected -Dengine to be of type build.Engine.
  error:   access the help menu with 'zig build -h'
  ```

  and

  ```
  Project-Specific Options:
    -Dtarget=[string]            The CPU architecture, OS, and ABI to build for
    [...]
    -Dengine=[enum]              JS engine (v8)
                                   Supported Values:
                                     v8
  ```

- `buildOptions()` is fallible for no reason after using the right options API
- Everything after `@hasDecl(build_opts, "engine")` is dead code, this is always true
- Even if the intention was to check value for its null state (also defaulted here, `build_opts.engine orelse "v8"`) the build system already adds v8 to the build graph due to `Options.engine` being non-nullable with a fallback value
- If all of this worked correctly and you could specify the engine via a root declaration, it could not return a value in its `engine()` function due to `EngineType` being an exhaustive enum hardcoded in the library

Overall that last part is a nice idea but obviously it's not been tested. It can be added back with all the above in mind at a later point. (e.g. explicit `-Dengine=custom` to not pull in v8 deps, non-exhaustive enum for custom values, etc)