### PR TITLE
load modules

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -17,7 +17,7 @@ inputs:
   zig-v8:
     description: 'zig v8 version to install'
     required: false
-    default: 'v0.1.9'
+    default: 'v0.1.11'
   v8:
     description: 'v8 version to install'
     required: false

--- a/src/api.zig
+++ b/src/api.zig
@@ -87,6 +87,9 @@ pub const Inspector = Engine.Inspector;
 pub const InspectorOnResponseFn = *const fn (ctx: *anyopaque, call_id: u32, msg: []const u8) void;
 pub const InspectorOnEventFn = *const fn (ctx: *anyopaque, msg: []const u8) void;
 
+pub const Module = Engine.Module;
+pub const ModuleLoadFn = Engine.ModuleLoadFn;
+
 pub const EngineType = enum {
     v8,
 };


### PR DESCRIPTION
* depends on https://github.com/lightpanda-io/zig-v8-fork/pull/31
* depends on https://github.com/lightpanda-io/zig-v8-fork/pull/34

The lib expects the client implements a function to fetch and compile the modules.
This function must be registered with `setModuleLoadFn` (maybe `registerModuleLoadFn1 would be a better name :thinking: ).

Example of client implementation in  https://github.com/lightpanda-io/browser/pull/345/commits/48e7c8ad0f1e716f76d6da22559974e3c37da0b6