### PR TITLE
Use https:// instead of git@ for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "vendor/zig-v8"]
 	path = vendor/zig-v8
-	url = git@github.com:Browsercore/zig-v8-fork.git
+	url = https://github.com/Browsercore/zig-v8-fork.git/
 [submodule "vendor/tigerbeetle-io"]
 	path = vendor/tigerbeetle-io
-	url = git@github.com:Browsercore/tigerbeetle-io.git
+	url = https://github.com/Browsercore/tigerbeetle-io.git/
 [submodule "vendor/linenoise-mob"]
 	path = vendor/linenoise-mob
-	url = git@github.com:rain-1/linenoise-mob.git
+	url = https://github.com/rain-1/linenoise-mob.git/


### PR DESCRIPTION
Allows building without a github account or special git configuration.

Related: https://github.com/lightpanda-io/browser/pull/393