### PR TITLE
Fix crash on js to native error

### DIFF
--- a/src/engines/v8/generate.zig
+++ b/src/engines/v8/generate.zig
@@ -213,13 +213,13 @@ fn getArg(
             cbk.Func, cbk.FuncSync, cbk.Arg => unreachable,
             JSObject => JSObject{ .nat_ctx = nat_ctx, .js_ctx = js_ctx, .js_obj = this },
             JSObjectID => JSObjectID.set(js_val.?.castTo(v8.Object)),
-            else => jsToNative(
+            else => try jsToNative(
                 alloc,
                 arg.T,
                 js_val.?,
                 isolate,
                 js_ctx,
-            ) catch unreachable,
+            ),
         };
     }
 

--- a/src/engines/v8/types_primitives.zig
+++ b/src/engines/v8/types_primitives.zig
@@ -143,7 +143,7 @@ pub fn jsToNative(
                 const v = js_val.castTo(v8.BigInt);
                 return v.getInt64();
             }
-            unreachable;
+            return @intCast(try js_val.toI32(ctx));
         },
 
         // integers unsigned
@@ -161,7 +161,7 @@ pub fn jsToNative(
                 const v = js_val.castTo(v8.BigInt);
                 return v.getUint64();
             }
-            unreachable;
+            return @intCast(try js_val.toU32(ctx));
         },
 
         // bool

--- a/src/engines/v8/types_primitives.zig
+++ b/src/engines/v8/types_primitives.zig
@@ -125,17 +125,17 @@ pub fn jsToNative(
         },
 
         // floats
-        f32 => return try js_val.toF32(ctx),
-        f64 => return try js_val.toF64(ctx),
+        f32 => return js_val.toF32(ctx) catch return error.InvalidArgument,
+        f64 => return js_val.toF64(ctx) catch return error.InvalidArgument,
 
         // integers signed
         i8, i16 => {
-            const v = try js_val.toI32(ctx);
+            const v = js_val.toI32(ctx) catch return error.InvalidArgument;
             return @as(T, @intCast(v));
         },
-        i32 => return try js_val.toI32(ctx),
+        i32 => return js_val.toI32(ctx) catch return error.InvalidArgument,
         i64Num => {
-            const v = try js_val.bitCastToI64(ctx);
+            const v = js_val.bitCastToI64(ctx) catch return error.InvalidArgument;
             return i64Num.init(v);
         },
         i64 => {
@@ -143,17 +143,17 @@ pub fn jsToNative(
                 const v = js_val.castTo(v8.BigInt);
                 return v.getInt64();
             }
-            return @intCast(try js_val.toI32(ctx));
+            return @intCast(js_val.toI32(ctx) catch return error.InvalidArgument);
         },
 
         // integers unsigned
         u8, u16 => {
-            const v = try js_val.toU32(ctx);
+            const v = js_val.toU32(ctx) catch return error.InvalidArgument;
             return @as(T, @intCast(v));
         },
-        u32 => return try js_val.toU32(ctx),
+        u32 => return js_val.toU32(ctx) catch return error.InvalidArgument,
         u64Num, ?u64Num => {
-            const v = try js_val.bitCastToU64(ctx);
+            const v = js_val.bitCastToU64(ctx) catch return error.InvalidArgument;
             return u64Num.init(v);
         },
         u64 => {
@@ -161,7 +161,7 @@ pub fn jsToNative(
                 const v = js_val.castTo(v8.BigInt);
                 return v.getUint64();
             }
-            return @intCast(try js_val.toU32(ctx));
+            return @intCast(js_val.toU32(ctx) catch return error.InvalidArgument);
         },
 
         // bool

--- a/src/tests/types_primitives_test.zig
+++ b/src/tests/types_primitives_test.zig
@@ -162,6 +162,9 @@ pub fn exec(
         .{ .src = "const big_int = 9007199254740995n", .ex = "undefined" },
         .{ .src = "p.checkI64(big_int) === big_int", .ex = "true" },
         .{ .src = "p.checkU64(big_int) === big_int;", .ex = "true" },
+        .{ .src = "p.checkI64(0) === 0n;", .ex = "true" },
+        .{ .src = "p.checkI64(-1) === -1n;", .ex = "true" },
+        .{ .src = "p.checkU64(0) === 0n;", .ex = "true" },
 
         // Floats
         // use round 2 decimals for float to ensure equality

--- a/src/tests/types_primitives_test.zig
+++ b/src/tests/types_primitives_test.zig
@@ -148,6 +148,7 @@ pub fn exec(
         .{ .src = "const min_i32 = -2147483648", .ex = "undefined" },
         .{ .src = "p.checkI32(min_i32) === min_i32;", .ex = "true" },
         .{ .src = "p.checkI32(min_i32-1) === min_i32-1;", .ex = "false" },
+        .{ .src = "try { p.checkI32(9007199254740995n) } catch(e) { e instanceof TypeError; }", .ex = "true" },
 
         // unsigned
         .{ .src = "const max_u32 = 4294967295", .ex = "undefined" },


### PR DESCRIPTION
Fixes 2 issues:
1 - When we expect an i64/u64, don't crash (unreachable) if it isn't stored as a BigInt in v8. No reason that `0` can't be assigned to an i64/u64.

2 - `jsToNative` can return legitimate errors. This should not be treated as `unreachble` 

(This PR includes https://github.com/lightpanda-io/zig-js-runtime/pull/282, which I'll close now)