### PR TITLE
Introduce InspectorSession 

### DIFF
--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -220,7 +220,7 @@ pub fn Inspector(comptime T: type, comptime Env_T: type) void {
     ) void);
 
     // send()
-    assertDecl(T, "send", fn (self: T, env: Env_T, msg: []const u8) void);
+    assertDecl(T, "send", fn (self: T, env: *const Env_T, msg: []const u8) void);
 }
 
 // Utils


### PR DESCRIPTION
I also changed the passed in `env: Env` ->  `env: *const Env` since Env is a medium-sized object. So this will require a small change in Browser (passing `&session.env` instead of `session.env`)