### PR TITLE
Take *const Env as argument instead of Env

### DIFF
--- a/src/engines/v8/callback.zig
+++ b/src/engines/v8/callback.zig
@@ -273,15 +273,12 @@ pub const Func = struct {
         ) orelse return error.V8ObjectNotFound;
     }
 
-    pub fn deinit(self: Func, alloc: std.mem.Allocator) void {
+    pub fn deinit(self: *Func, alloc: std.mem.Allocator) void {
 
         // cleanup persistent references in v8
-        var js_func_pers = self.js_func_pers; // TODO: why do we need var here?
-        js_func_pers.deinit();
-
-        for (self.js_args_pers) |arg| {
-            var arg_pers = arg; // TODO: why do we need var here?
-            arg_pers.deinit();
+        self.js_func_pers.deinit();
+        for (self.js_args_pers) |*arg| {
+            arg.deinit();
         }
 
         // free heap

--- a/src/interfaces.zig
+++ b/src/interfaces.zig
@@ -119,7 +119,7 @@ pub fn Env(
 pub fn JSValue(comptime T: type, env: type) void {
 
     // toString()
-    assertDecl(T, "toString", fn (self: T, alloc: std.mem.Allocator, env: env) anyerror![]const u8);
+    assertDecl(T, "toString", fn (self: T, alloc: std.mem.Allocator, env: *const env) anyerror![]const u8);
 
     // typeOf()
     assertDecl(T, "typeOf", fn (self: T, env: env) anyerror!public.JSTypes);
@@ -134,7 +134,7 @@ pub fn JSObjectID(comptime T: type) void {
 pub fn TryCatch(comptime T: type, comptime env: type) void {
 
     // init()
-    assertDecl(T, "init", fn (self: *T, env: env) void);
+    assertDecl(T, "init", fn (self: *T, env: *const env) void);
 
     // deinit()
     assertDecl(T, "deinit", fn (self: *T) void);
@@ -146,21 +146,21 @@ pub fn TryCatch(comptime T: type, comptime env: type) void {
     assertDecl(T, "exception", fn (
         self: T,
         alloc: std.mem.Allocator,
-        env: env,
+        env: *const env,
     ) anyerror!?[]const u8);
 
     // err()
     assertDecl(T, "err", fn (
         self: T,
         alloc: std.mem.Allocator,
-        env: env,
+        env: *const env,
     ) anyerror!?[]const u8);
 
     // stack()
     assertDecl(T, "stack", fn (
         self: T,
         alloc: std.mem.Allocator,
-        env: env,
+        env: *const env,
     ) anyerror!?[]const u8);
 }
 
@@ -201,7 +201,7 @@ pub fn Inspector(comptime T: type, comptime Env_T: type) void {
     // init()
     assertDecl(T, "init", fn (
         alloc: std.mem.Allocator,
-        env: Env_T,
+        env: *const Env_T,
         ctx: *anyopaque,
         onResp: public.InspectorOnResponseFn,
         onEvent: public.InspectorOnEventFn,
@@ -213,7 +213,7 @@ pub fn Inspector(comptime T: type, comptime Env_T: type) void {
     // contextCreated()
     assertDecl(T, "contextCreated", fn (
         self: T,
-        env: Env_T,
+        env: *const Env_T,
         name: []const u8,
         origin: []const u8,
         auxData: ?[]const u8,

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -150,7 +150,7 @@ pub const SingleThreaded = struct {
         };
 
         // js callback
-        if (ctx.js_cbk) |js_cbk| {
+        if (ctx.js_cbk) |*js_cbk| {
             defer js_cbk.deinit(ctx.loop.alloc);
             js_cbk.call(null) catch {
                 ctx.loop.cbk_error = true;

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -209,7 +209,7 @@ pub const SingleThreaded = struct {
         };
 
         // js callback
-        if (ctx.js_cbk) |js_cbk| {
+        if (ctx.js_cbk) |*js_cbk| {
             defer js_cbk.deinit(ctx.loop.alloc);
             js_cbk.call(null) catch {
                 ctx.loop.cbk_error = true;

--- a/src/tests/test_utils.zig
+++ b/src/tests/test_utils.zig
@@ -87,7 +87,7 @@ pub fn checkCasesAlloc(allocator: std.mem.Allocator, js_env: *public.Env, cases:
     var has_error = false;
 
     var try_catch: public.TryCatch = undefined;
-    try_catch.init(js_env.*);
+    try_catch.init(js_env);
     defer try_catch.deinit();
 
     // cases
@@ -103,7 +103,7 @@ pub fn checkCasesAlloc(allocator: std.mem.Allocator, js_env: *public.Env, cases:
         const res = js_env.execWait(case.src, name) catch |err| {
 
             // is it an intended error?
-            const except = try try_catch.exception(alloc, js_env.*);
+            const except = try try_catch.exception(alloc, js_env);
             if (except) |msg| {
                 defer alloc.free(msg);
                 if (isTypeError(case.ex, msg)) continue;
@@ -119,7 +119,7 @@ pub fn checkCasesAlloc(allocator: std.mem.Allocator, js_env: *public.Env, cases:
                 error.JSExecCallback => case.cbk_ex,
                 else => return err,
             };
-            if (try try_catch.stack(alloc, js_env.*)) |stack| {
+            if (try try_catch.stack(alloc, js_env)) |stack| {
                 defer alloc.free(stack);
                 caseError(case.src, expected, except.?, stack);
             }
@@ -127,7 +127,7 @@ pub fn checkCasesAlloc(allocator: std.mem.Allocator, js_env: *public.Env, cases:
         };
 
         // check if result is expected
-        const res_string = try res.toString(alloc, js_env.*);
+        const res_string = try res.toString(alloc, js_env);
         defer alloc.free(res_string);
         const equal = std.mem.eql(u8, case.ex, res_string);
         if (!equal) {


### PR DESCRIPTION
Env is a fairly large object, so rather than passing a copy, it should be better to pass a reference. This will require a few changes to Browser.