### PR TITLE
micro tasks: run micro tasks on isolate every 1 millisecond

### DIFF
--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -142,6 +142,7 @@ pub const Env = struct {
             .globals = globals,
         };
         NativeContext.init(&self.nat_ctx, alloc, loop, userctx);
+        self.loopMicrotasks();
     }
 
     pub fn deinit(self: *Env) void {
@@ -177,6 +178,15 @@ pub const Env = struct {
 
     pub fn setUserContext(self: *Env, userctx: public.UserContext) anyerror!void {
         self.nat_ctx.userctx = userctx;
+    }
+
+    fn loopMicrotasks(self: *Env) void {
+        self.isolate.performMicrotasksCheckpoint();
+        self.nat_ctx.loop.zigTimeout(1 * std.time.ns_per_ms, *Env, self, loopMicrotasks);
+    }
+
+    pub fn runMicrotasks(self: *Env) void {
+        self.isolate.performMicrotasksCheckpoint();
     }
 
     // load user-defined Types into Javascript environement

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -82,6 +82,11 @@ pub const VM = struct {
         v8.deinitV8Platform();
         self.platform.deinit();
     }
+
+    pub fn pumpMessageLoop(self: *const VM, env: *const Env, wait: bool) bool {
+        log.debug("pumpMessageLoop", .{});
+        return self.platform.pumpMessageLoop(env.isolate, wait);
+    }
 };
 
 pub const Env = struct {

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -43,9 +43,17 @@ pub const SingleThreaded = struct {
     events_nb: *usize,
     cbk_error: bool = false,
 
-    // ctx_id is incremented each time the loop is reset.
-    // All context are
-    ctx_id: u32 = 0,
+    // js_ctx_id is incremented each time the loop is reset for JS.
+    // All JS callbacks store an initial js_ctx_id and compare before execution.
+    // If a ctx is outdated, the callback is ignored.
+    // This is a weak way to cancel all future JS callbacks.
+    js_ctx_id: u32 = 0,
+
+    // zig_ctx_id is incremented each time the loop is reset for Zig.
+    // All Zig callbacks store an initial zig_ctx_id and compare before execution.
+    // If a ctx is outdated, the callback is ignored.
+    // This is a weak way to cancel all future Zig callbacks.
+    zig_ctx_id: u32 = 0,
 
     const Self = @This();
     pub const Completion = IO.Completion;
@@ -120,7 +128,7 @@ pub const SingleThreaded = struct {
     const ContextTimeout = struct {
         loop: *Self,
         js_cbk: ?JSCallback,
-        ctx_id: u32,
+        js_ctx_id: u32,
     };
 
     fn timeoutCallback(
@@ -133,7 +141,7 @@ pub const SingleThreaded = struct {
         // If the loop's context id has changed, don't call the js callback
         // function. The callback's memory has already be cleaned and the
         // events nb reset.
-        if (ctx.ctx_id != ctx.loop.ctx_id) return;
+        if (ctx.js_ctx_id != ctx.loop.js_ctx_id) return;
 
         const old_events_nb = ctx.loop.removeEvent();
         if (builtin.is_test) {
@@ -165,7 +173,7 @@ pub const SingleThreaded = struct {
         ctx.* = ContextTimeout{
             .loop = self,
             .js_cbk = js_cbk,
-            .ctx_id = self.ctx_id,
+            .js_ctx_id = self.js_ctx_id,
         };
         const old_events_nb = self.addEvent();
         self.io.timeout(*ContextTimeout, ctx, timeoutCallback, completion, nanoseconds);
@@ -179,7 +187,7 @@ pub const SingleThreaded = struct {
     const ContextCancel = struct {
         loop: *Self,
         js_cbk: ?JSCallback,
-        ctx_id: u32,
+        js_ctx_id: u32,
     };
 
     fn cancelCallback(
@@ -192,7 +200,7 @@ pub const SingleThreaded = struct {
         // If the loop's context id has changed, don't call the js callback
         // function. The callback's memory has already be cleaned and the
         // events nb reset.
-        if (ctx.ctx_id != ctx.loop.ctx_id) return;
+        if (ctx.js_ctx_id != ctx.loop.js_ctx_id) return;
 
         const old_events_nb = ctx.loop.removeEvent();
         if (builtin.is_test) {
@@ -226,7 +234,7 @@ pub const SingleThreaded = struct {
         ctx.* = ContextCancel{
             .loop = self,
             .js_cbk = js_cbk,
-            .ctx_id = self.ctx_id,
+            .js_ctx_id = self.js_ctx_id,
         };
 
         const old_events_nb = self.addEvent();
@@ -241,9 +249,15 @@ pub const SingleThreaded = struct {
         self.io.cancel_all();
     }
 
-    // Reset all existing callbacks.
-    pub fn reset(self: *Self) void {
-        self.ctx_id += 1;
+    // Reset all existing JS callbacks.
+    pub fn resetJS(self: *Self) void {
+        self.js_ctx_id += 1;
+        self.resetEvents();
+    }
+
+    // Reset all existing Zig callbacks.
+    pub fn resetZig(self: *Self) void {
+        self.zig_ctx_id += 1;
         self.resetEvents();
     }
 
@@ -329,7 +343,7 @@ pub const SingleThreaded = struct {
 
     const ContextZigTimeout = struct {
         loop: *Self,
-        ctx_id: u32,
+        zig_ctx_id: u32,
 
         context: *anyopaque,
         callback: *const fn (
@@ -347,7 +361,7 @@ pub const SingleThreaded = struct {
         // If the loop's context id has changed, don't call the js callback
         // function. The callback's memory has already be cleaned and the
         // events nb reset.
-        if (ctx.ctx_id != ctx.loop.ctx_id) return;
+        if (ctx.zig_ctx_id != ctx.loop.zig_ctx_id) return;
 
         // We don't remove event here b/c we don't want the main loop to wait for
         // the timeout is done.
@@ -380,7 +394,7 @@ pub const SingleThreaded = struct {
         const ctxtimeout = self.alloc.create(ContextZigTimeout) catch unreachable;
         ctxtimeout.* = ContextZigTimeout{
             .loop = self,
-            .ctx_id = self.ctx_id,
+            .zig_ctx_id = self.zig_ctx_id,
             .context = context,
             .callback = struct {
                 fn wrapper(ctx: ?*anyopaque) void {


### PR DESCRIPTION
This PR exposes `runMicrotasks` and `pumpMessageLoop`.
It also run  `runMicrotasks` every millisecond using timeouts.

I'm not sure if it's correct to implement this loop using timeout to run the `runMicrotasks`.
pro: it is handled by zig js runtime transparently
con: the caller doesn't control the delay between the runs

Fix #56