### PR TITLE
Add RemoteObject subtype

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -182,7 +182,7 @@ pub fn packages(comptime vendor_path: []const u8) type {
             mod.addIncludePath(b.path(vendor ++ "/zig-v8/src"));
 
             const build_opts = b.addOptions();
-            build_opts.addOption(bool, "inspector_subtype", true);
+            build_opts.addOption(bool, "inspector_subtype", false);
             mod.addOptions("default_exports", build_opts);
             return mod;
         }

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -747,6 +747,10 @@ fn getExternalEntry(value: v8.Value) ?*ExternalEntry {
         return null;
     }
     const obj = value.castTo(Object);
+    if (obj.internalFieldCount() == 0) {
+        return null;
+    }
+
     const external_data = obj.getInternalField(0).castTo(v8.External).get().?;
     return @alignCast(@ptrCast(external_data));
 }

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -698,3 +698,55 @@ pub const Inspector = struct {
         return self.session.dispatchProtocolMessage(env.isolate, msg);
     }
 };
+
+// When we return a Zig instance to V8, we wrap it in a v8.Object. That wrapping
+// happens by:
+//  - Assigning our instance to a v8.External (which just holds an *anyopaque)
+//  - Creating a v8.PersistentObject and assigning the external to the
+//    PersistentObject's internalField #0
+//  - Casting the v8.PersistentObject to a v8.Object
+//
+// Now, instead of assigning the instance directly into the v8.External we
+// allocate and assign this ExternalEntry, which allows us to hold the ptr to
+// the Zig instance, as well as meta data that we'll need.
+pub const ExternalEntry = struct {
+    // Ptr to the Zig instance
+    ptr: *anyopaque,
+
+    // When we're asked to describe an object via the Inspector, we _must_ include
+    // the proper subtype (and description) fields in the returned JSON.
+    // V8 will give us a Value and ask us for the subtype. Hence, we store it
+    // here.
+    sub_type: ?[:0]const u8,
+};
+
+// See above for documentation for the ExternalEntry's sub_type field.
+pub export fn v8_inspector__Client__IMPL__valueSubtype(
+    _: *v8.c.InspectorClientImpl,
+    c_value: *const v8.C_Value,
+) callconv(.C) [*c]const u8 {
+    const external_entry = getExternalEntry(.{ .handle = c_value }) orelse return null;
+    return if (external_entry.sub_type) |st| st else null;
+}
+
+pub export fn v8_inspector__Client__IMPL__descriptionForValueSubtype(
+    _: *v8.c.InspectorClientImpl,
+    context: *const v8.C_Context,
+    c_value: *const v8.C_Value,
+) callconv(.C) [*c]const u8 {
+    _ = context;
+
+    // We _must_ include a non-null description in order for the subtype value
+    // to be included. Besides that, I don't know if the value has any meaning
+    const external_entry = getExternalEntry(.{ .handle = c_value }) orelse return null;
+    return if (external_entry.sub_type == null) null else "";
+}
+
+fn getExternalEntry(value: v8.Value) ?*ExternalEntry {
+    if (value.isObject() == false) {
+        return null;
+    }
+    const obj = value.castTo(Object);
+    const external_data = obj.getInternalField(0).castTo(v8.External).get().?;
+    return @alignCast(@ptrCast(external_data));
+}

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -717,7 +717,7 @@ pub const ExternalEntry = struct {
     // the proper subtype (and description) fields in the returned JSON.
     // V8 will give us a Value and ask us for the subtype. Hence, we store it
     // here.
-    sub_type: ?[:0]const u8,
+    sub_type: ?[*c]const u8,
 };
 
 // See above for documentation for the ExternalEntry's sub_type field.

--- a/src/reflect.zig
+++ b/src/reflect.zig
@@ -785,7 +785,7 @@ pub const Struct = struct {
 
     // nested types
     nested: []const StructNested,
-    sub_type: ?[:0]const u8,
+    sub_type: ?[*c]const u8,
 
     pub fn Self(comptime self: Struct) type {
         comptime {
@@ -1247,7 +1247,7 @@ pub const Struct = struct {
             mem_guarantied = @typeInfo(T).@"struct".layout != .auto;
         }
 
-        var sub_type: ?[:0]const u8 = null;
+        var sub_type: ?[*c]const u8 = null;
         if (@hasDecl(T, "sub_type")) {
             sub_type = @field(T, "sub_type");
         }

--- a/src/reflect.zig
+++ b/src/reflect.zig
@@ -785,6 +785,7 @@ pub const Struct = struct {
 
     // nested types
     nested: []const StructNested,
+    sub_type: ?[:0]const u8,
 
     pub fn Self(comptime self: Struct) type {
         comptime {
@@ -1246,6 +1247,11 @@ pub const Struct = struct {
             mem_guarantied = @typeInfo(T).@"struct".layout != .auto;
         }
 
+        var sub_type: ?[:0]const u8 = null;
+        if (@hasDecl(T, "sub_type")) {
+            sub_type = @field(T, "sub_type");
+        }
+
         // nested types
         var nested_nb: usize = 0;
         // first iteration to retrieve the number of nested structs
@@ -1430,6 +1436,7 @@ pub const Struct = struct {
 
             // nested types
             .nested = &cnested,
+            .sub_type = sub_type,
         };
     }
 };

--- a/src/refs.zig
+++ b/src/refs.zig
@@ -26,11 +26,8 @@ const refl = internal.refl;
 pub const Map = std.AutoHashMapUnmanaged(usize, usize);
 
 pub fn getObject(map: Map, comptime T: type, comptime types: []const refl.Struct, ptr: anytype) !*T {
-
-    // use the object pointer (key) to retrieve the API index (value) in the map
-    const ptr_aligned: *align(@alignOf(usize)) anyopaque = @alignCast(ptr);
-    const key: *usize = @ptrCast(ptr_aligned);
-    const T_index = map.get(key.*);
+    const key: usize = @intFromPtr(ptr);
+    const T_index = map.get(key);
     if (T_index == null) {
         return error.NullReference;
     }
@@ -42,7 +39,7 @@ pub fn getObject(map: Map, comptime T: type, comptime types: []const refl.Struct
             if (!T_refl.isEmpty()) { // stage1: condition is needed for empty structs
                 // go through the "proto" object chain
                 // to retrieve the good object corresponding to T
-                const target_ptr: *T_refl.Self() = @ptrFromInt(key.*);
+                const target_ptr: *T_refl.Self() = @ptrFromInt(key);
                 return try getRealObject(T, target_ptr);
             }
         }


### PR DESCRIPTION
Allow Zig structures to define a `sub_type` which will be included in the RemoteObject's subtype field (and will generate an empty description field)

External PersitedObjects now wrap our own ExternalEntry wrapper, which includes a pointer to the Zig instance (what we used to have before). This approach allows us to associate metadata with a v8.Value. We currently add the subtype if available.