### PR TITLE
Const NativeContext for getV8Object

### DIFF
--- a/src/engines/v8/callback.zig
+++ b/src/engines/v8/callback.zig
@@ -134,7 +134,7 @@ pub const FuncSync = struct {
 
     pub fn setThisArg(self: *FuncSync, nat_obj_ptr: anytype) !void {
         self.thisArg = try getV8Object(
-            self.nat_ctx,
+            self.nat_ctx.*,
             nat_obj_ptr,
         ) orelse return error.V8ObjectNotFound;
     }
@@ -263,7 +263,7 @@ pub const Func = struct {
 
     pub fn setThisArg(self: *Func, nat_obj_ptr: anytype) !void {
         self.thisArg = try getV8Object(
-            self.nat_ctx,
+            self.nat_ctx.*,
             nat_obj_ptr,
         ) orelse return error.V8ObjectNotFound;
     }

--- a/src/engines/v8/callback.zig
+++ b/src/engines/v8/callback.zig
@@ -134,7 +134,7 @@ pub const FuncSync = struct {
 
     pub fn setThisArg(self: *FuncSync, nat_obj_ptr: anytype) !void {
         self.thisArg = try getV8Object(
-            self.nat_ctx.*,
+            self.nat_ctx,
             nat_obj_ptr,
         ) orelse return error.V8ObjectNotFound;
     }
@@ -263,7 +263,7 @@ pub const Func = struct {
 
     pub fn setThisArg(self: *Func, nat_obj_ptr: anytype) !void {
         self.thisArg = try getV8Object(
-            self.nat_ctx.*,
+            self.nat_ctx,
             nat_obj_ptr,
         ) orelse return error.V8ObjectNotFound;
     }

--- a/src/engines/v8/generate.zig
+++ b/src/engines/v8/generate.zig
@@ -522,7 +522,7 @@ inline fn initJSObject(
 
 // getV8Object returns the existing v8.Object corresponding to the given native
 // pointer from the native context.
-pub fn getV8Object(nat_ctx: NativeContext, nat_obj_ptr: anytype) !?v8.Object {
+pub fn getV8Object(nat_ctx: *const NativeContext, nat_obj_ptr: anytype) !?v8.Object {
     // ensure Native object is a pointer
     if (comptime !refl.isPointer(@TypeOf(nat_obj_ptr))) return error.NotAPointer;
 

--- a/src/engines/v8/generate.zig
+++ b/src/engines/v8/generate.zig
@@ -522,7 +522,7 @@ inline fn initJSObject(
 
 // getV8Object returns the existing v8.Object corresponding to the given native
 // pointer from the native context.
-pub fn getV8Object(nat_ctx: *NativeContext, nat_obj_ptr: anytype) !?v8.Object {
+pub fn getV8Object(nat_ctx: NativeContext, nat_obj_ptr: anytype) !?v8.Object {
     // ensure Native object is a pointer
     if (comptime !refl.isPointer(@TypeOf(nat_obj_ptr))) return error.NotAPointer;
 


### PR DESCRIPTION
A small change to allow getV8Object to be called for a constant NativeContext.
Aside from being const-correct the change is needed for a later PR regarding resolveNode.

~~Note: I'm assuming Zig takes large parameters by pointer under the hood.~~