### PR TITLE
Inspector session wrapObject wrapper

### DIFF
--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -720,7 +720,7 @@ pub const Inspector = struct {
         return self.session.dispatchProtocolMessage(env.isolate, msg);
     }
 
-    // inspector's wrapObject for use in resolveNode. We may extending the interface here to include:
+    // Inspector's wrapObject for use in resolveNode. We may extend the interface here to include:
     // backendNodeId, objectGroup, executionContextId. For a complete resolveNode implementation at this level.
     // node_ptr is expected to be a sub-type of *parser.Node
     pub fn wrapObject(self: Inspector, env: *Env, node_ptr: anytype) !v8.RemoteObject {

--- a/src/engines/v8/v8.zig
+++ b/src/engines/v8/v8.zig
@@ -355,6 +355,10 @@ pub const Env = struct {
     // Currently used for DOM nodes
     // - value Note: *parser.Node should be converted to dom/node.zig.Union to get the most precise type
     pub fn findOrAddValue(env: *Env, value: anytype) !v8.Value {
+        if (builtin.is_test) {
+            // std.testing.refAllDecls(@import("server.zig")); Causes `try ret.lookup(gen.Types);` to throw an error
+            return error.TestingNotSupported;
+        }
         comptime var ret: refl.Type = undefined;
         comptime {
             @setEvalBranchQuota(150_000); // Needed when this is called with a dom/node.zig.Union


### PR DESCRIPTION
Things to consider:
- ~~Do we want to call this wrapObject or resolveNode?~~
- Is it OK to pass the v8.RemoteObject? Since it is a CDP specific type I don't think there is a need to wrap it again.
- Do we want this to exist at all or should CDP.dom.resolveNode() just hold this logic?
- Currently we accept anytype. Alternatively this code take a parser.Node, which we would have to down cast to the correct type. How to do that is TBD, but needs to be figured out in the Browser anyway.
- Temporary defaults are kept here as opposed to in the zig-v8 repo to give that repo a cleaner/more final interface.

Depends on: ~~https://github.com/lightpanda-io/zig-v8-fork/pull/49~~