### PR TITLE
Undo b757c823410b51122e15e2500115f9c1705f6aff

### DIFF
--- a/src/loop.zig
+++ b/src/loop.zig
@@ -293,14 +293,12 @@ pub const SingleThreaded = struct {
     // Reset all existing JS callbacks.
     pub fn resetJS(self: *Self) void {
         self.js_ctx_id += 1;
-        self.resetEvents(.js);
         self.cancelled.clearRetainingCapacity();
     }
 
     // Reset all existing Zig callbacks.
     pub fn resetZig(self: *Self) void {
         self.zig_ctx_id += 1;
-        self.resetEvents(.zig);
     }
 
     // IO callbacks APIs


### PR DESCRIPTION
This reverts https://github.com/lightpanda-io/zig-js-runtime/pull/299

The point of that PR was to fix the crashing WPT tests, but, as pointed out in that PR, that might introduce issues. I think with cancel  now pseudo-working on MacOS, there's a different way to solve that